### PR TITLE
docs(zh): translate DevTools release notes and remaining docs

### DIFF
--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.10.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.10.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.10.0 release notes
-shortTitle: 2.10.0 release notes
+# title: DevTools 2.10.0 release notes
+title: DevTools 2.10.0 版本说明
+# shortTitle: 2.10.0 release notes
+shortTitle: 2.10.0 版本说明
 breadcrumb: 2.10.0
-description: Release notes for Dart and Flutter DevTools version 2.10.0.
+# description: Release notes for Dart and Flutter DevTools version 2.10.0.
+description: Dart 和 Flutter DevTools 2.10.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.10.0 release of the Dart and Flutter DevTools
@@ -11,38 +15,76 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.10.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Flutter inspector updates
+
+## Flutter 检查器更新
 
 * Added search support to the Widget Tree, and
   added a breadcrumb navigator to the Widget Details Tree to
   allow for quickly navigating through the tree hierarchy -
   [#3525](https://github.com/flutter/devtools/pull/3525)
 
+  为 Widget Tree 添加了搜索支持，
+  并为 Widget Details Tree 添加了面包屑导航器，
+  让你可以快速浏览树形层级结构 -
+  [#3525](https://github.com/flutter/devtools/pull/3525)
+
   ![inspector search](/assets/images/docs/tools/devtools/release-notes/images-2.10.0/image1.png "inspector_search")
 
 ## CPU profiler updates
+
+## CPU 性能分析器更新
 
 * Fix a null reference in the CPU profiler
   when loading an offline snapshot -
   [#3596](https://github.com/flutter/devtools/pull/3596)
 
+  修复了加载离线快照时 CPU 性能分析器中的空引用问题 -
+  [#3596](https://github.com/flutter/devtools/pull/3596)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Added support for multi-token file search, and
   improved search match prioritization to
   rank file name matches over full path matches -
   [#3582](https://github.com/flutter/devtools/pull/3582)
+
+  添加了多词元文件搜索支持，
+  并改进了搜索匹配优先级，
+  使文件名匹配优先于完整路径匹配 -
+  [#3582](https://github.com/flutter/devtools/pull/3582)
 * Fix some focus-related issues -
   [#3602](https://github.com/flutter/devtools/pull/3602)
 
+  修复了一些与焦点相关的问题 -
+  [#3602](https://github.com/flutter/devtools/pull/3602)
+
 ## Logging view updates
+
+## 日志视图更新
 
 * Fix a fatal error that occurred when
   filtering logs more than once -
   [#3588](https://github.com/flutter/devtools/pull/3588)
 
+  修复了多次过滤日志时发生的致命错误 -
+  [#3588](https://github.com/flutter/devtools/pull/3588)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.9.2...v2.10.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.9.2...v2.10.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.11.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.11.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.11.2 release notes
-shortTitle: 2.11.2 release notes
+# title: DevTools 2.11.2 release notes
+title: DevTools 2.11.2 版本说明
+# shortTitle: 2.11.2 release notes
+shortTitle: 2.11.2 版本说明
 breadcrumb: 2.11.2
-description: Release notes for Dart and Flutter DevTools version 2.11.2.
+# description: Release notes for Dart and Flutter DevTools version 2.11.2.
+description: Dart 和 Flutter DevTools 2.11.2 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.11.2 release of the Dart and Flutter DevTools
@@ -11,24 +15,49 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.11.2 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * This release included a lot of cleanup and reduction in technical debt.
 
+  此版本包含大量清理工作和技术债务的削减。
+
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Added the source line number to file uris in CPU profiles -
+  [#3718](https://github.com/flutter/devtools/pull/3718)
+
+  在 CPU 性能分析配置中为文件 URI 添加了源代码行号 -
   [#3718](https://github.com/flutter/devtools/pull/3718)
 
   ![cpu stack frame line numbers](/assets/images/docs/tools/devtools/release-notes/images-2.11.2/image1.png "cpu stack frame line numbers")
 
 ## Debugger updates
 
+## 调试器更新
+
 * File opener UX improvements, including support for clicking
   the source file name to open the file search window -
   [#3612](https://github.com/flutter/devtools/pull/3612),
   [#3758](https://github.com/flutter/devtools/pull/3758)
+
+  改进了文件打开器的用户体验，包括支持点击
+  源文件名以打开文件搜索窗口 -
+  [#3612](https://github.com/flutter/devtools/pull/3612),
+  [#3758](https://github.com/flutter/devtools/pull/3758)
 * Added support for auto-scrolling the File Explorer to the selected file -
+  [#3786](https://github.com/flutter/devtools/pull/3786),
+  [#3794](https://github.com/flutter/devtools/pull/3794)
+
+  添加了自动滚动 File Explorer 至所选文件的支持 -
   [#3786](https://github.com/flutter/devtools/pull/3786),
   [#3794](https://github.com/flutter/devtools/pull/3794)
 
@@ -36,6 +65,12 @@ To learn more about DevTools, check out the
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.10.0...v2.11.2).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.10.0...v2.11.2)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.12.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.12.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.12.1 release notes
-shortTitle: 2.12.1 release notes
+# title: DevTools 2.12.1 release notes
+title: DevTools 2.12.1 版本说明
+# shortTitle: 2.12.1 release notes
+shortTitle: 2.12.1 版本说明
 breadcrumb: 2.12.1
-description: Release notes for Dart and Flutter DevTools version 2.12.1.
+# description: Release notes for Dart and Flutter DevTools version 2.12.1.
+description: Dart 和 Flutter DevTools 2.12.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.12.1 release of the Dart and Flutter DevTools
@@ -11,16 +15,32 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.12.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * This release included a lot of cleanup and reduction in technical debt.
 
+  此版本包含大量清理工作和技术债务的削减。
+
 ## Flutter inspector updates
+
+## Flutter 检查器更新
 
 * Added scrolling support to hover cards -
   [#3923](https://github.com/flutter/devtools/pull/3923)
 
+  为悬停卡片添加了滚动支持 -
+  [#3923](https://github.com/flutter/devtools/pull/3923)
+
 ## Performance updates
+
+## 性能更新
 
 * Added documentation links to the
   "Enhance Tracing" and "More debugging options" menus.
@@ -30,10 +50,24 @@ To learn more about DevTools, check out the
   [#3934](https://github.com/flutter/devtools/pull/3934),
   [#3936](https://github.com/flutter/devtools/pull/3936)
 
+  为「Enhance Tracing」和「More debugging options」菜单
+  添加了文档链接。
+  阅读
+  [增强追踪文档](https://docs.flutter.dev/tools/devtools/performance#enhance-tracing)
+  以了解更多关于这些功能的信息 -
+  [#3934](https://github.com/flutter/devtools/pull/3934),
+  [#3936](https://github.com/flutter/devtools/pull/3936)
+
   ![enhance tracing documentation links](/assets/images/docs/tools/devtools/release-notes/images-2.12.1/image1.png "enhance tracing documentation links")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.11.2...v2.12.1).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.11.2...v2.12.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.12.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.12.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.12.2 release notes
-shortTitle: 2.12.2 release notes
+# title: DevTools 2.12.2 release notes
+title: DevTools 2.12.2 版本说明
+# shortTitle: 2.12.2 release notes
+shortTitle: 2.12.2 版本说明
 breadcrumb: 2.12.2
-description: Release notes for Dart and Flutter DevTools version 2.12.2.
+# description: Release notes for Dart and Flutter DevTools version 2.12.2.
+description: Dart 和 Flutter DevTools 2.12.2 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.12.2 release of the Dart and Flutter DevTools
@@ -11,13 +15,29 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.12.2 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Recover from missing trace events -
   [#3960](https://github.com/flutter/devtools/pull/3960)
 
+  从缺失的追踪事件中恢复 -
+  [#3960](https://github.com/flutter/devtools/pull/3960)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.12.1...v2.12.2).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.12.1...v2.12.2)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.13.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.13.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.13.1 release notes
-shortTitle: 2.13.1 release notes
+# title: DevTools 2.13.1 release notes
+title: DevTools 2.13.1 版本说明
+# shortTitle: 2.13.1 release notes
+shortTitle: 2.13.1 版本说明
 breadcrumb: 2.13.1
-description: Release notes for Dart and Flutter DevTools version 2.13.1.
+# description: Release notes for Dart and Flutter DevTools version 2.13.1.
+description: Dart 和 Flutter DevTools 2.13.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.13.1 release of the Dart and Flutter DevTools
@@ -11,11 +15,24 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.13.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * This release included a lot of cleanup and reduction in technical debt.
   The most notable is the completion of our migration to sound null safety.
+
+  此版本包含大量清理工作和技术债务的削减。
+  最值得注意的是完成了向健全空安全的迁移。
 * Show release notes in IDE embedded versions of DevTools -
+  [#4053](https://github.com/flutter/devtools/pull/4053)
+
+  在 IDE 嵌入式版本的 DevTools 中显示版本说明 -
   [#4053](https://github.com/flutter/devtools/pull/4053)
 * Polish to the DevTools footer -
   [#3989](https://github.com/flutter/devtools/pull/3989),
@@ -23,13 +40,27 @@ To learn more about DevTools, check out the
   [#4041](https://github.com/flutter/devtools/pull/4041),
   [#4076](https://github.com/flutter/devtools/pull/4076)
 
+  优化了 DevTools 页脚 -
+  [#3989](https://github.com/flutter/devtools/pull/3989),
+  [#4026](https://github.com/flutter/devtools/pull/4026),
+  [#4041](https://github.com/flutter/devtools/pull/4041),
+  [#4076](https://github.com/flutter/devtools/pull/4076)
+
 ## Performance updates
+
+## 性能更新
 
 * Added a new feature to help you debug raster jank in your Flutter app.
   This feature allows you to take a snapshot of the
   current screen shown in your app, and then
   break down rendering time for that scene by layer.
   This can help you identify parts of a scene that are expensive to rasterize -
+  [#4046](https://github.com/flutter/devtools/pull/4046)
+
+  添加了一项新功能，帮助你调试 Flutter 应用中的光栅化卡顿。
+  此功能让你可以对应用中当前显示的屏幕进行快照，
+  然后按图层分解该场景的渲染时间。
+  这可以帮助你识别场景中光栅化开销较大的部分 -
   [#4046](https://github.com/flutter/devtools/pull/4046)
 
   ![raster-metrics-feature](/assets/images/docs/tools/devtools/release-notes/images-2.13.1/image1.png "raster metrics feature")
@@ -39,25 +70,51 @@ To learn more about DevTools, check out the
   your code only or in all code -
   [#4010](https://github.com/flutter/devtools/pull/4010)
 
+  为「Track Widget Builds」添加了作用域设置，
+  让你可以指定是仅追踪你的代码中的 widget 构建，
+  还是追踪所有代码中的 widget 构建 -
+  [#4010](https://github.com/flutter/devtools/pull/4010)
+
   ![track-widget-builds-scope-setting](/assets/images/docs/tools/devtools/release-notes/images-2.13.1/image2.png "track widget builds scope setting")
 
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Use package uris instead of file uris in the CPU profiler "Source" column -
+  [#3932](https://github.com/flutter/devtools/pull/3932)
+
+  在 CPU 性能分析器的「Source」列中使用 package URI 而非 file URI -
   [#3932](https://github.com/flutter/devtools/pull/3932)
 
 ## Debugger updates
 
+## 调试器更新
+
 * Fix scrolling bug with debugger breakpoints -
+  [#4074](https://github.com/flutter/devtools/pull/4074)
+
+  修复了调试器断点的滚动 bug -
   [#4074](https://github.com/flutter/devtools/pull/4074)
 
 ## Flutter inspector updates
 
+## Flutter 检查器更新
+
 * Add support for displaying flex values larger than 5 in the Layout Explorer -
+  [#4055](https://github.com/flutter/devtools/pull/4055)
+
+  在 Layout Explorer 中添加了对显示大于 5 的 flex 值的支持 -
   [#4055](https://github.com/flutter/devtools/pull/4055)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.12.2...v2.13.1).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.12.2...v2.13.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.14.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.14.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.14.0 release notes
-shortTitle: 2.14.0 release notes
+# title: DevTools 2.14.0 release notes
+title: DevTools 2.14.0 版本说明
+# shortTitle: 2.14.0 release notes
+shortTitle: 2.14.0 版本说明
 breadcrumb: 2.14.0
-description: Release notes for Dart and Flutter DevTools version 2.14.0.
+# description: Release notes for Dart and Flutter DevTools version 2.14.0.
+description: Dart 和 Flutter DevTools 2.14.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.14.0 release of the Dart and Flutter DevTools
@@ -11,59 +15,116 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.14.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Added a link to the new DevTools
   [Discord channel](https://discord.com/channels/608014603317936148/958862085297672282)
   in the About DevTools dialog -
   [#4102](https://github.com/flutter/devtools/pull/4102)
 
+  在「关于 DevTools」对话框中添加了指向新 DevTools
+  [Discord 频道](https://discord.com/channels/608014603317936148/958862085297672282)
+  的链接 -
+  [#4102](https://github.com/flutter/devtools/pull/4102)
+
   ![about-devtools](/assets/images/docs/tools/devtools/release-notes/images-2.14.0/image1.png "about devtools")
 
 ## Network updates
+
+## 网络更新
 
 * Added "Copy as URL" and "Copy as cURL" actions for
   selected requests in the network profiler
   (special thanks to [@jankuss](https://github.com/jankuss)!) -
   [#4113](https://github.com/flutter/devtools/pull/4113)
 
+  为网络性能分析器中所选请求添加了
+  「Copy as URL」和「Copy as cURL」操作
+  （特别感谢 [@jankuss](https://github.com/jankuss)！）-
+  [#4113](https://github.com/flutter/devtools/pull/4113)
+
   ![network-request-copy-actions](/assets/images/docs/tools/devtools/release-notes/images-2.14.0/image2.png "network request copy actions")
 
 ## Flutter inspector updates
+
+## Flutter 检查器更新
 
 * Added a setting to control whether hovering over a widget
   in the inspector displays its properties and values in a hover card -
   [#4090](https://github.com/flutter/devtools/pull/4090)
 
+  添加了一项设置，用于控制悬停在检查器中的 widget 上时
+  是否在悬停卡片中显示其属性和值 -
+  [#4090](https://github.com/flutter/devtools/pull/4090)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Added auto complete suggestions in the console
   (special thanks to [@jankuss](https://github.com/jankuss)!) -
+  [#4062](https://github.com/flutter/devtools/pull/4062)
+
+  在控制台中添加了自动补全建议
+  （特别感谢 [@jankuss](https://github.com/jankuss)！）-
   [#4062](https://github.com/flutter/devtools/pull/4062)
 
   ![auto-complete-suggestions](/assets/images/docs/tools/devtools/release-notes/images-2.14.0/image3.png "auto complete suggestions")
 
 * Added the option to copy the full file path for a selected library -
   [#4147](https://github.com/flutter/devtools/pull/4147)
+
+  添加了复制所选库完整文件路径的选项 -
+  [#4147](https://github.com/flutter/devtools/pull/4147)
 * Fixed formatting in the debugger exception menu -
+  [#4066](https://github.com/flutter/devtools/pull/4066)
+
+  修复了调试器异常菜单中的格式问题 -
   [#4066](https://github.com/flutter/devtools/pull/4066)
 
 ## Memory updates
 
+## 内存更新
+
 * Fixed formatting for memory values in the heap tree view -
+  [#4153](https://github.com/flutter/devtools/pull/4153)
+
+  修复了堆树视图中内存值的格式问题 -
   [#4153](https://github.com/flutter/devtools/pull/4153)
 * Fixed a bug that was preventing GC events from
   showing up in the memory chart -
   [#4131](https://github.com/flutter/devtools/pull/4131)
 
+  修复了一个阻止 GC 事件在内存图表中显示的 bug -
+  [#4131](https://github.com/flutter/devtools/pull/4131)
+
 ## Performance updates
+
+## 性能更新
 
 * Warn users that the rendering layer toggles in the
   "More Debugging Options" menu are not available for profile mode apps -
   [#4075](https://github.com/flutter/devtools/pull/4075)
 
+  警告用户「More Debugging Options」菜单中的渲染层切换
+  不适用于 profile 模式应用 -
+  [#4075](https://github.com/flutter/devtools/pull/4075)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.13.1...v2.14.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.13.1...v2.14.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.15.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.15.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.15.0 release notes
-shortTitle: 2.15.0 release notes
+# title: DevTools 2.15.0 release notes
+title: DevTools 2.15.0 版本说明
+# shortTitle: 2.15.0 release notes
+shortTitle: 2.15.0 版本说明
 breadcrumb: 2.15.0
-description: Release notes for Dart and Flutter DevTools version 2.15.0.
+# description: Release notes for Dart and Flutter DevTools version 2.15.0.
+description: Dart 和 Flutter DevTools 2.15.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.15.0 release of the Dart and Flutter DevTools
@@ -11,15 +15,31 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.15.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * The DevTools 2.15 release includes improvements to all tables in
   DevTools (logging view, network profiler, CPU profiler, and so on) -
   [#4175](https://github.com/flutter/devtools/pull/4175)
 
+  DevTools 2.15 版本改进了 DevTools 中的所有表格
+  （日志视图、网络性能分析器、CPU 性能分析器等）-
+  [#4175](https://github.com/flutter/devtools/pull/4175)
+
 ## Performance updates
 
+## 性能更新
+
 * Added outlines to each layer displayed in the Raster Metrics tool -
+  [#4192](https://github.com/flutter/devtools/pull/4192)
+
+  为 Raster Metrics 工具中显示的每个图层添加了轮廓 -
   [#4192](https://github.com/flutter/devtools/pull/4192)
 
   ![raster-metrics-layer-outlines](/assets/images/docs/tools/devtools/release-notes/images-2.15.0/image1.png "raster metrics layer outlines")
@@ -27,9 +47,17 @@ To learn more about DevTools, check out the
 * Fix a bug with loading offline data -
   [#4189](https://github.com/flutter/devtools/pull/4189)
 
+  修复了加载离线数据的 bug -
+  [#4189](https://github.com/flutter/devtools/pull/4189)
+
 ## Network updates
 
+## 网络更新
+
 * Added a Json viewer with syntax highlighting for network responses -
+  [#4167](https://github.com/flutter/devtools/pull/4167)
+
+  为网络响应添加了带语法高亮的 Json 查看器 -
   [#4167](https://github.com/flutter/devtools/pull/4167)
 
   ![network-response-json-viewer](/assets/images/docs/tools/devtools/release-notes/images-2.15.0/image2.png "network response json viewer")
@@ -37,20 +65,42 @@ To learn more about DevTools, check out the
 * Added the ability to copy network responses -
   [#4190](https://github.com/flutter/devtools/pull/4190)
 
+  添加了复制网络响应的功能 -
+  [#4190](https://github.com/flutter/devtools/pull/4190)
+
 ## Memory updates
 
+## 内存更新
+
 * Added the ability to select a different isolate from the DevTools footer -
+  [#4173](https://github.com/flutter/devtools/pull/4173)
+
+  添加了从 DevTools 页脚选择不同 isolate 的功能 -
   [#4173](https://github.com/flutter/devtools/pull/4173)
 * Made the automatic snapshotting feature a configurable setting -
   [#4200](https://github.com/flutter/devtools/pull/4200)
 
+  将自动快照功能设为可配置设置 -
+  [#4200](https://github.com/flutter/devtools/pull/4200)
+
 ## CPU profiler
+
+## CPU 性能分析器
 
 * Stop manually truncating source URIs in the profiler tables -
   [#4166](https://github.com/flutter/devtools/pull/4166)
 
+  停止在性能分析器表格中手动截断源 URI -
+  [#4166](https://github.com/flutter/devtools/pull/4166)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.14.0...v2.15.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.14.0...v2.15.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.16.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.16.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.16.0 release notes
-shortTitle: 2.16.0 release notes
+# title: DevTools 2.16.0 release notes
+title: DevTools 2.16.0 版本说明
+# shortTitle: 2.16.0 release notes
+shortTitle: 2.16.0 版本说明
 breadcrumb: 2.16.0
-description: Release notes for Dart and Flutter DevTools version 2.16.0.
+# description: Release notes for Dart and Flutter DevTools version 2.16.0.
+description: Dart 和 Flutter DevTools 2.16.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.16.0 release of the Dart and Flutter DevTools
@@ -11,13 +15,29 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.16.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 This release includes several bug fixes and improvements, as well as
 work towards some new features that are coming soon!
 
+此版本包含多项 bug 修复和改进，
+以及即将推出的新功能的开发工作！
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.15.0...v2.16.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.15.0...v2.16.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.17.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.17.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.17.0 release notes
-shortTitle: 2.17.0 release notes
+# title: DevTools 2.17.0 release notes
+title: DevTools 2.17.0 版本说明
+# shortTitle: 2.17.0 release notes
+shortTitle: 2.17.0 版本说明
 breadcrumb: 2.17.0
-description: Release notes for Dart and Flutter DevTools version 2.17.0.
+# description: Release notes for Dart and Flutter DevTools version 2.17.0.
+description: Dart 和 Flutter DevTools 2.17.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.17.0 release of the Dart and Flutter DevTools
@@ -11,7 +15,14 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.17.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Inspector updates
+
+## 检查器更新
 
 * Added support for manually setting the package directories for your app.
   If you've ever loaded the Inspector and noticed that
@@ -27,9 +38,21 @@ To learn more about DevTools, check out the
   directories are properly configured -
   [#4306](https://github.com/flutter/devtools/pull/4306)
 
+  添加了手动设置应用 package 目录的支持。
+  如果你曾加载检查器并注意到某些 widget 未出现在 widget 树中，
+  这可能表明应用的 package 目录未正确设置或检测。
+  package 目录决定了检查器将哪些 widget 视为来自*你的*应用。
+  如果你看到空的检查器 widget 树，
+  或者你在多个 package 中开发 widget，
+  并希望所有这些位置的 widget 都显示在树中，
+  请检查 **Inspector Settings** 对话框，确保 package 目录配置正确 -
+  [#4306](https://github.com/flutter/devtools/pull/4306)
+
   ![frame_analysis](/assets/images/docs/tools/devtools/release-notes/images-2.17.0/package_directories.png "package directories")
 
 ## Performance updates
+
+## 性能更新
 
 * Added a **Frame Analysis** tab to the Performance page.
   When analyzing a janky Flutter frame,
@@ -41,10 +64,25 @@ To learn more about DevTools, check out the
   to try to guide you in the right direction -
   [#4339](https://github.com/flutter/devtools/pull/4339)
 
+  在 Performance 页面添加了 **Frame Analysis** 标签页。
+  分析卡顿的 Flutter 帧时，
+  此视图提供诊断卡顿的提示，
+  并检测可能导致帧时间变慢的昂贵操作。
+  此视图还按阶段（**Build**、**Layout**、**Paint** 和 **Raster**）
+  分解 Flutter 帧时间，
+  帮助你找到正确的方向 -
+  [#4339](https://github.com/flutter/devtools/pull/4339)
+
   ![frame_analysis](/assets/images/docs/tools/devtools/release-notes/images-2.17.0/frame_analysis.png "frame analysis")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.16.0...v2.17.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.16.0...v2.17.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.18.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.18.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.18.0 release notes
-shortTitle: 2.18.0 release notes
+# title: DevTools 2.18.0 release notes
+title: DevTools 2.18.0 版本说明
+# shortTitle: 2.18.0 release notes
+shortTitle: 2.18.0 版本说明
 breadcrumb: 2.18.0
-description: Release notes for Dart and Flutter DevTools version 2.18.0.
+# description: Release notes for Dart and Flutter DevTools version 2.18.0.
+description: Dart 和 Flutter DevTools 2.18.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.18.0 release of the Dart and Flutter DevTools
@@ -11,38 +15,80 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.18.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Inspector updates
 
+## 检查器更新
+
 - Auto scrolling behavior improved when snapping a widget into focus -
+  [#4283](https://github.com/flutter/devtools/pull/4283)
+
+  改进了将 widget 聚焦时的自动滚动行为 -
   [#4283](https://github.com/flutter/devtools/pull/4283)
 - Fix issue where widget inspector wouldn't load when
   connecting to a paused app -
   [#4527](https://github.com/flutter/devtools/pull/4527)
+
+  修复了连接到已暂停应用时 widget 检查器无法加载的问题 -
+  [#4527](https://github.com/flutter/devtools/pull/4527)
 - Improve widget inspector hover cards to show progress while waiting for data -
+  [#4488](https://github.com/flutter/devtools/pull/4488)
+
+  改进了 widget 检查器悬停卡片，在等待数据时显示进度 -
   [#4488](https://github.com/flutter/devtools/pull/4488)
 
 ## Performance updates
 
+## 性能更新
+
 - Fix issue where scrollbar would go out of sync with the frame content -
+  [#4503](https://github.com/flutter/devtools/pull/4503)
+
+  修复了滚动条与帧内容不同步的问题 -
   [#4503](https://github.com/flutter/devtools/pull/4503)
 - Add offline support for raster stats -
   [#4491](https://github.com/flutter/devtools/pull/4491)
+
+  为光栅统计添加了离线支持 -
+  [#4491](https://github.com/flutter/devtools/pull/4491)
 - Add 'Rendering time' column to Raster Metrics tab -
+  [#4474](https://github.com/flutter/devtools/pull/4474)
+
+  在 Raster Metrics 标签页中添加了「Rendering time」列 -
   [#4474](https://github.com/flutter/devtools/pull/4474)
 
   ![render-time-column](/assets/images/docs/tools/devtools/release-notes/images-2.18.0/render-time-column.png "Rendering time column in the Raster Metrics tab")
 
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 - Fix crash when an empty frame is filtered -
+  [#4502](https://github.com/flutter/devtools/pull/4502)
+
+  修复了过滤空帧时的崩溃问题 -
   [#4502](https://github.com/flutter/devtools/pull/4502)
 - Fix bugs in CPU profile trees -
   [#4413](https://github.com/flutter/devtools/pull/4413)
+
+  修复了 CPU 性能分析树中的 bug -
+  [#4413](https://github.com/flutter/devtools/pull/4413)
 - UI Cleanup - [#4404](https://github.com/flutter/devtools/pull/4404)
+
+  UI 清理 - [#4404](https://github.com/flutter/devtools/pull/4404)
 
 ## Memory updates
 
+## 内存更新
+
 - Add Profile and Allocation Tracing sub-tabs -
+  [#4523](https://github.com/flutter/devtools/pull/4523)
+
+  添加了 Profile 和 Allocation Tracing 子标签页 -
   [#4523](https://github.com/flutter/devtools/pull/4523)
 
   ![profile](/assets/images/docs/tools/devtools/release-notes/images-2.18.0/profile.png "Profile in Memory tab")
@@ -52,28 +98,58 @@ To learn more about DevTools, check out the
 - Implement snapshot visualization -
   [#4473](https://github.com/flutter/devtools/pull/4473)
 
+  实现了快照可视化 -
+  [#4473](https://github.com/flutter/devtools/pull/4473)
+
 ## Debugger updates
+
+## 调试器更新
 
 - Fix bug for file opener and search -
   [#4525](https://github.com/flutter/devtools/pull/4525)
+
+  修复了文件打开器和搜索的 bug -
+  [#4525](https://github.com/flutter/devtools/pull/4525)
 - Fix the code view's scrollable area -
+  [#4448](https://github.com/flutter/devtools/pull/4448)
+
+  修复了代码视图的可滚动区域 -
   [#4448](https://github.com/flutter/devtools/pull/4448)
 - Allow syntax highlighting on nested captures in parser -
   [#4427](https://github.com/flutter/devtools/pull/4427)
 
+  允许解析器对嵌套捕获进行语法高亮 -
+  [#4427](https://github.com/flutter/devtools/pull/4427)
+
 ## Network profiler updates
+
+## 网络性能分析器更新
 
 - When on the Network tab, network recordings now continue working
   after the app hot restarts -
   [#4438](https://github.com/flutter/devtools/pull/4438)
 
+  在 Network 标签页上，应用热重启后网络录制现在可以继续工作 -
+  [#4438](https://github.com/flutter/devtools/pull/4438)
+
 ## Logging updates
+
+## 日志更新
 
 - Log messages from non-stdout sources are now shown -
   [#4487](https://github.com/flutter/devtools/pull/4487)
 
+  现在会显示来自非 stdout 源的日志消息 -
+  [#4487](https://github.com/flutter/devtools/pull/4487)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.17.0...v2.18.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.17.0...v2.18.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.19.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.19.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.19.0 release notes
-shortTitle: 2.19.0 release notes
+# title: DevTools 2.19.0 release notes
+title: DevTools 2.19.0 版本说明
+# shortTitle: 2.19.0 release notes
+shortTitle: 2.19.0 版本说明
 breadcrumb: 2.19.0
-description: Release notes for Dart and Flutter DevTools version 2.19.0.
+# description: Release notes for Dart and Flutter DevTools version 2.19.0.
+description: Dart 和 Flutter DevTools 2.19.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.19.0 release of the Dart and Flutter DevTools
@@ -11,9 +15,19 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.19.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Performance updates
 
+## 性能更新
+
 * Added a button to toggle the visibility of the Flutter Frames chart -
+  [#4577](https://github.com/flutter/devtools/pull/4577)
+
+  添加了切换 Flutter Frames 图表可见性的按钮 -
   [#4577](https://github.com/flutter/devtools/pull/4577)
 
   ![diff](/assets/images/docs/tools/devtools/release-notes/images-2.19.0/4577.png "Flutter Frames")
@@ -21,31 +35,64 @@ To learn more about DevTools, check out the
 * Polish the debug mode warning to better describe which data is
   accurate in debug mode and which data may be misleading -
   [#3537](https://github.com/flutter/devtools/pull/3537)
+
+  优化了 debug 模式警告，更好地描述哪些数据在 debug 模式下准确，
+  哪些数据可能具有误导性 -
+  [#3537](https://github.com/flutter/devtools/pull/3537)
 * Reorder performance tool tabs and only show the CPU profiler
   for the "Timeline Events" tab -
   [#4629](https://github.com/flutter/devtools/pull/4629)
 
+  重新排列了性能工具标签页，并仅在「Timeline Events」标签页中
+  显示 CPU 性能分析器 -
+  [#4629](https://github.com/flutter/devtools/pull/4629)
+
 ## Memory updates
+
+## 内存更新
 
 * Improvements to the memory Profile tab -
   [#4583](https://github.com/flutter/devtools/pull/4583)
 
+  改进了内存 Profile 标签页 -
+  [#4583](https://github.com/flutter/devtools/pull/4583)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Fix an issue with hover cards where they were appearing
   but never disappearing -
   [#4627](https://github.com/flutter/devtools/pull/4627)
+
+  修复了悬停卡片出现后永不消失的问题 -
+  [#4627](https://github.com/flutter/devtools/pull/4627)
 * Fix a bug with the file search autocomplete dialog -
   [#4409](https://github.com/flutter/devtools/pull/4409)
 
+  修复了文件搜索自动补全对话框的 bug -
+  [#4409](https://github.com/flutter/devtools/pull/4409)
+
 ## Network profiler updates
+
+## 网络性能分析器更新
 
 * Added a "Copy" button in the Network Request view
   (thanks to @netos23) -
   [#4509](https://github.com/flutter/devtools/pull/4509)
 
+  在 Network Request 视图中添加了「Copy」按钮
+  （感谢 @netos23）-
+  [#4509](https://github.com/flutter/devtools/pull/4509)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.18.0...v2.19.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.18.0...v2.19.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.20.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.20.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.20.0 release notes
-shortTitle: 2.20.0 release notes
+# title: DevTools 2.20.0 release notes
+title: DevTools 2.20.0 版本说明
+# shortTitle: 2.20.0 release notes
+shortTitle: 2.20.0 版本说明
 breadcrumb: 2.20.0
-description: Release notes for Dart and Flutter DevTools version 2.20.0.
+# description: Release notes for Dart and Flutter DevTools version 2.20.0.
+description: Dart 和 Flutter DevTools 2.20.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.20.0 release of the Dart and Flutter DevTools
@@ -11,14 +15,27 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.20.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Add support for grouping samples by tag -
+  [#4693](https://github.com/flutter/devtools/pull/4693)
+
+  添加了按标签对样本进行分组的支持 -
   [#4693](https://github.com/flutter/devtools/pull/4693)
 
   ![samples by tag](/assets/images/docs/tools/devtools/release-notes/images-2.20.0/4693.png "samples by tag")
 
 * Enable guidelines for tree view -
+  [#4722](https://github.com/flutter/devtools/pull/4722)
+
+  为树形视图启用了参考线 -
   [#4722](https://github.com/flutter/devtools/pull/4722)
 
   ![guidelines](/assets/images/docs/tools/devtools/release-notes/images-2.20.0/4722.png "guidelines")
@@ -27,12 +44,21 @@ To learn more about DevTools, check out the
   and move down to the area it relates to -
   [#4803](https://github.com/flutter/devtools/pull/4722)
 
+  将「Profile granularity」重命名为「CPU sampling rate」
+  并移至相关区域 -
+  [#4803](https://github.com/flutter/devtools/pull/4722)
+
   ![sampling rate](/assets/images/docs/tools/devtools/release-notes/images-2.20.0/4803.png "sampling rate")
 
 
 ## Memory updates
 
+## 内存更新
+
 * Retire the **Analysis** tab -
+  [#4714](https://github.com/flutter/devtools/pull/4714)
+
+  移除了 **Analysis** 标签页 -
   [#4714](https://github.com/flutter/devtools/pull/4714)
 
 * Add a new tab, **Diff**, to enable memory leak detection
@@ -41,28 +67,55 @@ To learn more about DevTools, check out the
   shallow size, retained size, and retaining paths -
   [#4714](https://github.com/flutter/devtools/pull/4714)
 
+  添加了新标签页 **Diff**，通过比较堆快照
+  实现内存泄漏检测和故障排除，
+  提供实例数量、浅层大小、保留大小和保留路径的洞察 -
+  [#4714](https://github.com/flutter/devtools/pull/4714)
+
   ![diff](/assets/images/docs/tools/devtools/release-notes/images-2.20.0/4714.png "Diff in Memory tab")
 
 ## Debugger updates
+
+## 调试器更新
 
 * Support for inspecting more types of instances in the variables viewer
   (Expandos, Types, TypeArguments, Parameters, Closures + closure Contexts,
   WeakProperty, Function, FunctionType, ReceivePort, Closure, RegExp) -
   [#4760](https://github.com/flutter/devtools/pull/4760)
 
+  在变量查看器中支持检查更多类型的实例
+  （Expandos、Types、TypeArguments、Parameters、Closures + closure Contexts、
+  WeakProperty、Function、FunctionType、ReceivePort、Closure、RegExp）-
+  [#4760](https://github.com/flutter/devtools/pull/4760)
+
 * Add support for displaying coverage in CodeView -
+  [#4700](https://github.com/flutter/devtools/pull/4700)
+
+  添加了在 CodeView 中显示覆盖率的支持 -
   [#4700](https://github.com/flutter/devtools/pull/4700)
 
   ![coverage](/assets/images/docs/tools/devtools/release-notes/images-2.20.0/4700.png "coverage in CodeView")
 
 ## Network updates
 
+## 网络更新
+
 * Display request data if content type is not json
   (thanks to @leungpuikuen!) -
   [#4602](https://github.com/flutter/devtools/pull/4602)
 
+  当内容类型不是 json 时显示请求数据
+  （感谢 @leungpuikuen！）-
+  [#4602](https://github.com/flutter/devtools/pull/4602)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.19.0...v2.20.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.19.0...v2.20.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.21.1 release notes
-shortTitle: 2.21.1 release notes
+# title: DevTools 2.21.1 release notes
+title: DevTools 2.21.1 版本说明
+# shortTitle: 2.21.1 release notes
+shortTitle: 2.21.1 版本说明
 breadcrumb: 2.22.1
-description: Release notes for Dart and Flutter DevTools version 2.21.1.
+# description: Release notes for Dart and Flutter DevTools version 2.21.1.
+description: Dart 和 Flutter DevTools 2.21.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.21.1 release of the Dart and Flutter DevTools
@@ -11,10 +15,21 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.21.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Performance updates
+
+## 性能更新
 
 * Replace the DevTools timeline trace viewer with
   the [Perfetto](https://perfetto.dev/) trace viewer -
+  [#5142](https://github.com/flutter/devtools/pull/5142)
+
+  将 DevTools 时间线追踪查看器替换为
+  [Perfetto](https://perfetto.dev/) 追踪查看器 -
   [#5142](https://github.com/flutter/devtools/pull/5142)
 
   ![perfetto trace viewer](/assets/images/docs/tools/devtools/release-notes/images-2.21.1/image1.png "perfetto_trace_viewer")
@@ -22,54 +37,118 @@ To learn more about DevTools, check out the
 * Fix several issues with loading a Performance snapshot into DevTools -
   [#5048](https://github.com/flutter/devtools/pull/5048),
   [#4929](https://github.com/flutter/devtools/pull/4929)
+
+  修复了将 Performance 快照加载到 DevTools 时的多个问题 -
+  [#5048](https://github.com/flutter/devtools/pull/5048),
+  [#4929](https://github.com/flutter/devtools/pull/4929)
 * UI polish and cleanup - [#4889](https://github.com/flutter/devtools/pull/4889)
+
+  UI 优化和清理 - [#4889](https://github.com/flutter/devtools/pull/4889)
 
 ## Memory updates
 
+## 内存更新
+
 * Improve usability of snapshot diffing -
   [#5015](https://github.com/flutter/devtools/pull/5015)
+
+  改进了快照差异对比的可用性 -
+  [#5015](https://github.com/flutter/devtools/pull/5015)
 * UI polish and cleanup -
+  [#4855](https://github.com/flutter/devtools/pull/4855)
+
+  UI 优化和清理 -
   [#4855](https://github.com/flutter/devtools/pull/4855)
 * Color code classes based on where they are defined
   (SDK, your package, dependencies, etc.) -
   [#5030](https://github.com/flutter/devtools/pull/5030)
+
+  根据类定义位置进行颜色编码
+  （SDK、你的 package、依赖项等）-
+  [#5030](https://github.com/flutter/devtools/pull/5030)
 * Fix state management issue for tracing -
   [#5062](https://github.com/flutter/devtools/pull/5062)
+
+  修复了追踪的状态管理问题 -
+  [#5062](https://github.com/flutter/devtools/pull/5062)
 * Improve the performance of taking a heap snapshot -
+  [#5134](https://github.com/flutter/devtools/pull/5134)
+
+  改进了获取堆快照的性能 -
   [#5134](https://github.com/flutter/devtools/pull/5134)
 * Retire broken import/export feature -
   [#5135](https://github.com/flutter/devtools/pull/5135)
 
+  移除了有问题的导入/导出功能 -
+  [#5135](https://github.com/flutter/devtools/pull/5135)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Added support for viewing profiler hits in
   the debugger script viewer -
   [#4831](https://github.com/flutter/devtools/pull/4831)
+
+  添加了在调试器脚本查看器中查看性能分析器命中次数的支持 -
+  [#4831](https://github.com/flutter/devtools/pull/4831)
 * Added support for inspecting records -
   [#5084](https://github.com/flutter/devtools/pull/5084)
 
+  添加了检查 record 的支持 -
+  [#5084](https://github.com/flutter/devtools/pull/5084)
+
 ## General updates
+
+## 常规更新
 
 * Fix several issues in syntax highlighting that would
   color variable names that contain reserved words incorrectly and
   leave `extends`/`implements` clauses uncolored for some classes -
   [#4948](https://github.com/flutter/devtools/pull/4948)
+
+  修复了语法高亮中的多个问题，
+  这些问题会错误地为包含保留字的变量名着色，
+  以及导致某些类的 `extends`/`implements` 子句未着色 -
+  [#4948](https://github.com/flutter/devtools/pull/4948)
 * Fix an issue in Safari, and
   other browsers that do not support RegExp negative lookbehind,
   that prevented DevTools from loading -
   [#4938](https://github.com/flutter/devtools/pull/4938)
+
+  修复了 Safari 及其他不支持 RegExp 负向后查找的浏览器中
+  导致 DevTools 无法加载的问题 -
+  [#4938](https://github.com/flutter/devtools/pull/4938)
 * Fix an issue that would prevent DevTools connecting to
   the backend server that would disable some functionality -
+  [#5016](https://github.com/flutter/devtools/pull/5016)
+
+  修复了阻止 DevTools 连接到后端服务器
+  从而导致部分功能不可用的问题 -
   [#5016](https://github.com/flutter/devtools/pull/5016)
 * Add a link to the DevTools
   [contribution guide](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md)
   to the About menu, and fixed the Discord link -
   [#4926](https://github.com/flutter/devtools/pull/4926)
+
+  在「关于」菜单中添加了 DevTools
+  [贡献指南](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md)
+  的链接，并修复了 Discord 链接 -
+  [#4926](https://github.com/flutter/devtools/pull/4926)
 * Fix conflicting colors in light theme -
+  [#5067](https://github.com/flutter/devtools/pull/5067)
+
+  修复了浅色主题中的颜色冲突 -
   [#5067](https://github.com/flutter/devtools/pull/5067)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.20.0...v2.21.1).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.20.0...v2.21.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
@@ -3,7 +3,7 @@
 title: DevTools 2.21.1 版本说明
 # shortTitle: 2.21.1 release notes
 shortTitle: 2.21.1 版本说明
-breadcrumb: 2.22.1
+breadcrumb: 2.21.1
 # description: Release notes for Dart and Flutter DevTools version 2.21.1.
 description: Dart 和 Flutter DevTools 2.21.1 版本的发布说明。
 showToc: false

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.22.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.22.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.22.2 release notes
-shortTitle: 2.22.2 release notes
+# title: DevTools 2.22.2 release notes
+title: DevTools 2.22.2 版本说明
+# shortTitle: 2.22.2 release notes
+shortTitle: 2.22.2 版本说明
 breadcrumb: 2.22.2
-description: Release notes for Dart and Flutter DevTools version 2.22.2.
+# description: Release notes for Dart and Flutter DevTools version 2.22.2.
+description: Dart 和 Flutter DevTools 2.22.2 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.22.2 release of the Dart and Flutter DevTools
@@ -11,15 +15,31 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.22.2 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 - Prevent crashes if there is no main isolate -
   [#5232](https://github.com/flutter/devtools/pull/5232)
 
+  在没有 main isolate 时防止崩溃 -
+  [#5232](https://github.com/flutter/devtools/pull/5232)
+
 ## CPU profiler updates
+
+## CPU 性能分析器更新
 
 - Display stack frame URI inline with method name to
   ensure the URI is always visible in deeply nested trees -
+  [#5181](https://github.com/flutter/devtools/pull/5181)
+
+  将堆栈帧 URI 与方法名内联显示，
+  确保在深层嵌套树中 URI 始终可见 -
   [#5181](https://github.com/flutter/devtools/pull/5181)
 
   ![inline uri](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5181.png "inline uri")
@@ -27,32 +47,58 @@ To learn more about DevTools, check out the
 - Add the ability to filter by method name or source URI -
   [#5204](https://github.com/flutter/devtools/pull/5204)
 
+  添加了按方法名或源 URI 过滤的功能 -
+  [#5204](https://github.com/flutter/devtools/pull/5204)
+
 ## Memory updates
+
+## 内存更新
 
 - Change filter default to show only project and 3rd party dependencies -
   [#5201](https://github.com/flutter/devtools/pull/5201).
+
+  将过滤器默认值更改为仅显示项目和第三方依赖 -
+  [#5201](https://github.com/flutter/devtools/pull/5201)。
 
   ![filter default](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5201.png "filter default")
 
 - Support expression evaluation in console for running application -
   [#5248](https://github.com/flutter/devtools/pull/5248).
 
+  为运行中的应用在控制台中支持表达式求值 -
+  [#5248](https://github.com/flutter/devtools/pull/5248)。
+
   ![evaluation](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5248.png "evaluation")
 
 - Add column `Persisted` for memory diffing -
+  [#5290](https://github.com/flutter/devtools/pull/5290)
+
+  为内存差异对比添加了 `Persisted` 列 -
   [#5290](https://github.com/flutter/devtools/pull/5290)
 
   ![persisted](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5290.png "persisted")
 
 ## Debugger updates
 
+## 调试器更新
+
 - Add support for browser navigation history when
   navigating using the File Explorer -
+  [#4906](https://github.com/flutter/devtools/pull/4906)
+
+  使用 File Explorer 导航时添加了浏览器导航历史支持 -
   [#4906](https://github.com/flutter/devtools/pull/4906)
 - Designate positional fields for `Record` types
   with the getter syntax beginning at `$1` -
   [#5272](https://github.com/flutter/devtools/pull/5272)
+
+  使用从 `$1` 开始的 getter 语法
+  为 `Record` 类型指定位置字段 -
+  [#5272](https://github.com/flutter/devtools/pull/5272)
 - Fix variable inspection for `Map` and `List` instances -
+  [#5320](https://github.com/flutter/devtools/pull/5320)
+
+  修复了 `Map` 和 `List` 实例的变量检查 -
   [#5320](https://github.com/flutter/devtools/pull/5320)
 
   ![map and list](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5320.png "map and list")
@@ -60,16 +106,30 @@ To learn more about DevTools, check out the
 - Fix variable inspection for `Set` instances -
   [#5323](https://github.com/flutter/devtools/pull/5323)
 
+  修复了 `Set` 实例的变量检查 -
+  [#5323](https://github.com/flutter/devtools/pull/5323)
+
   ![set](/assets/images/docs/tools/devtools/release-notes/images-2.22.2/5323.png "set")
 
 
 ## Network profiler updates
 
+## 网络性能分析器更新
+
 - Improve reliability and performance of the Network tab -
+  [#5056](https://github.com/flutter/devtools/pull/5056)
+
+  改进了 Network 标签页的可靠性和性能 -
   [#5056](https://github.com/flutter/devtools/pull/5056)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.21.1...v2.22.2).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.21.1...v2.22.2)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.23.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.23.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.23.1 release notes
-shortTitle: 2.23.1 release notes
+# title: DevTools 2.23.1 release notes
+title: DevTools 2.23.1 版本说明
+# shortTitle: 2.23.1 release notes
+shortTitle: 2.23.1 版本说明
 breadcrumb: 2.23.1
-description: Release notes for Dart and Flutter DevTools version 2.23.1.
+# description: Release notes for Dart and Flutter DevTools version 2.23.1.
+description: Dart 和 Flutter DevTools 2.23.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.23.1 release of the Dart and Flutter DevTools
@@ -11,42 +15,88 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.23.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Update DevTools to the new Material 3 design -
   [#5429](https://github.com/flutter/devtools/pull/5429)
+
+  将 DevTools 更新为新的 Material 3 设计 -
+  [#5429](https://github.com/flutter/devtools/pull/5429)
 * Use the default Flutter service worker -
   [#5331](https://github.com/flutter/devtools/pull/5331)
+
+  使用默认的 Flutter service worker -
+  [#5331](https://github.com/flutter/devtools/pull/5331)
 * Added the new verbose logging feature for helping us debug user issues -
+  [#5404](https://github.com/flutter/devtools/pull/5404)
+
+  添加了新的详细日志功能，帮助我们调试用户问题 -
   [#5404](https://github.com/flutter/devtools/pull/5404)
 
   ![verbose logging](/assets/images/docs/tools/devtools/release-notes/images-2.23.1/verbose-logging.png "verbose_logging")
 
 * Fix a bug where some asynchronous errors were not being reported -
   [#5456](https://github.com/flutter/devtools/pull/5456)
+
+  修复了部分异步错误未被报告的 bug -
+  [#5456](https://github.com/flutter/devtools/pull/5456)
 * Added support for viewing data after an app disconnects for
   screens that support offline viewing
   (currently only the Performance and CPU profiler pages) -
   [#5509](https://github.com/flutter/devtools/pull/5509)
+
+  为支持离线查看的页面添加了应用断开后查看数据的支持
+  （目前仅 Performance 和 CPU 性能分析器页面）-
+  [#5509](https://github.com/flutter/devtools/pull/5509)
 * Include settings button in the footer of the embedded view -
+  [#5528](https://github.com/flutter/devtools/pull/5528)
+
+  在嵌入式视图的页脚中包含设置按钮 -
   [#5528](https://github.com/flutter/devtools/pull/5528)
 
 ## Performance updates
 
+## 性能更新
+
 * Fix a performance regression in timeline event processing -
+  [#5460](https://github.com/flutter/devtools/pull/5460)
+
+  修复了时间线事件处理中的性能回退 -
   [#5460](https://github.com/flutter/devtools/pull/5460)
 * Persist a user's preference for whether the
   Flutter Frames chart should be shown by default -
   [#5339](https://github.com/flutter/devtools/pull/5339)
+
+  持久化用户对 Flutter Frames 图表是否默认显示的首选项 -
+  [#5339](https://github.com/flutter/devtools/pull/5339)
 * Point users to [Impeller](https://docs.flutter.dev/perf/impeller) when
   shader compilation jank is detected on an iOS device -
+  [#5455](https://github.com/flutter/devtools/pull/5455)
+
+  在 iOS 设备上检测到着色器编译卡顿时，
+  引导用户查看 [Impeller](https://docs.flutter.dev/perf/impeller) -
   [#5455](https://github.com/flutter/devtools/pull/5455)
 * Remove the CPU profiler from the legacy trace viewer -
   [#5539](https://github.com/flutter/devtools/pull/5539)
 
+  从旧版追踪查看器中移除了 CPU 性能分析器 -
+  [#5539](https://github.com/flutter/devtools/pull/5539)
+
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Add a Method Table to the CPU profiler -
+  [#5366](https://github.com/flutter/devtools/pull/5366)
+
+  为 CPU 性能分析器添加了 Method Table -
   [#5366](https://github.com/flutter/devtools/pull/5366)
 
   ![Method table](/assets/images/docs/tools/devtools/release-notes/images-2.23.1/cpu-method-table.png "method_table")
@@ -55,64 +105,144 @@ To learn more about DevTools, check out the
   [#5468](https://github.com/flutter/devtools/pull/5468),
   [#5533](https://github.com/flutter/devtools/pull/5533),
   [#5535](https://github.com/flutter/devtools/pull/5535)
+
+  改进了 CPU 性能分析器中数据处理的性能 -
+  [#5468](https://github.com/flutter/devtools/pull/5468),
+  [#5533](https://github.com/flutter/devtools/pull/5533),
+  [#5535](https://github.com/flutter/devtools/pull/5535)
 * Polish and performance improvements for the CPU profile flame chart -
+  [#5529](https://github.com/flutter/devtools/pull/5529)
+
+  优化了 CPU 性能分析火焰图并改进了性能 -
   [#5529](https://github.com/flutter/devtools/pull/5529)
 * Add ability to inspect statistics for a CPU profile -
   [#5340](https://github.com/flutter/devtools/pull/5340)
+
+  添加了查看 CPU 性能分析统计信息的功能 -
+  [#5340](https://github.com/flutter/devtools/pull/5340)
 * Fix a bug where Native stack frames were missing their name -
   [#5344](https://github.com/flutter/devtools/pull/5344)
+
+  修复了 Native 堆栈帧缺少名称的 bug -
+  [#5344](https://github.com/flutter/devtools/pull/5344)
 * Fix an error in total and self time calculations for the bottom up tree -
+  [#5348](https://github.com/flutter/devtools/pull/5348)
+
+  修复了 bottom up 树中总时间和自身时间计算的错误 -
   [#5348](https://github.com/flutter/devtools/pull/5348)
 * Add support for zooming and navigating the flame chart
   with ,AOE keys (helpful for Dvorak users) -
   [#5545](https://github.com/flutter/devtools/pull/5545)
 
+  添加了使用 ,AOE 键缩放和导航火焰图的支持
+  （对 Dvorak 键盘用户很有帮助）-
+  [#5545](https://github.com/flutter/devtools/pull/5545)
+
 ## Memory updates
+
+## 内存更新
 
 * Fix filtering bug in the "Trace Instances" view -
   [#5406](https://github.com/flutter/devtools/pull/5406)
+
+  修复了「Trace Instances」视图中的过滤 bug -
+  [#5406](https://github.com/flutter/devtools/pull/5406)
 * Enabled evaluation and browsing for instances in heap snapshot -
+  [#5542](https://github.com/flutter/devtools/pull/5542)
+
+  在堆快照中启用了实例的求值和浏览 -
   [#5542](https://github.com/flutter/devtools/pull/5542)
 * Fix heap snapshot failure -
   [#5520](https://github.com/flutter/devtools/pull/5520)
+
+  修复了堆快照失败的问题 -
+  [#5520](https://github.com/flutter/devtools/pull/5520)
 * Stop displaying external sizes in the allocation profile -
+  [#5555](https://github.com/flutter/devtools/pull/5555)
+
+  停止在 allocation profile 中显示 external sizes -
   [#5555](https://github.com/flutter/devtools/pull/5555)
 * Expose totals for memory in heap snapshot -
   [#5593](https://github.com/flutter/devtools/pull/5593)
 
+  在堆快照中显示内存总计 -
+  [#5593](https://github.com/flutter/devtools/pull/5593)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Fix a bug where variable inspection
   for instances sometimes showed no children -
   [#5356](https://github.com/flutter/devtools/pull/5356)
+
+  修复了实例变量检查有时不显示子项的 bug -
+  [#5356](https://github.com/flutter/devtools/pull/5356)
 * Hide "search in file" dialog if the "file search" dialog is open -
+  [#5393](https://github.com/flutter/devtools/pull/5393)
+
+  如果「file search」对话框已打开，则隐藏「search in file」对话框 -
   [#5393](https://github.com/flutter/devtools/pull/5393)
 * Fix file search bug where last letter disappeared when
   searching at end of file name -
   [#5397](https://github.com/flutter/devtools/pull/5397)
+
+  修复了在文件名末尾搜索时最后一个字母消失的 bug -
+  [#5397](https://github.com/flutter/devtools/pull/5397)
 * Add search icon in file bar to make file search more discoverable -
+  [#5351](https://github.com/flutter/devtools/issues/5351)
+
+  在文件栏中添加搜索图标，使文件搜索更容易被发现 -
   [#5351](https://github.com/flutter/devtools/issues/5351)
 * Allow expression evaluation when pausing in JS for web apps -
   [#5427](https://github.com/flutter/devtools/pull/5427)
+
+  允许在 Web 应用的 JS 中暂停时进行表达式求值 -
+  [#5427](https://github.com/flutter/devtools/pull/5427)
 * Update syntax highlighting to
+  [dart-lang/dart-syntax-highlight v1.2.0](https://github.com/dart-lang/dart-syntax-highlight/blob/master/CHANGELOG.md#120-2023-01-30) -
+  [#5477](https://github.com/flutter/devtools/pull/5477)
+
+  将语法高亮更新为
   [dart-lang/dart-syntax-highlight v1.2.0](https://github.com/dart-lang/dart-syntax-highlight/blob/master/CHANGELOG.md#120-2023-01-30) -
   [#5477](https://github.com/flutter/devtools/pull/5477)
 * Debugger panel respects "dense mode" -
   [#5517](https://github.com/flutter/devtools/pull/5517)
 
+  调试器面板遵循「dense mode」-
+  [#5517](https://github.com/flutter/devtools/pull/5517)
+
 ## Network profiler updates
+
+## 网络性能分析器更新
 
 * Fix a bug viewing JSON responses with null values -
   [#5424](https://github.com/flutter/devtools/pull/5424)
+
+  修复了查看包含 null 值的 JSON 响应的 bug -
+  [#5424](https://github.com/flutter/devtools/pull/5424)
 * Fix a bug where JSON requests were shown in plain text,
   instead of the formatted JSON viewer -
+  [#5463](https://github.com/flutter/devtools/pull/5463)
+
+  修复了 JSON 请求以纯文本而非格式化 JSON 查看器显示的 bug -
   [#5463](https://github.com/flutter/devtools/pull/5463)
 * Fix a UI issue where the copy button on the response or request tab
   would let you copy while still loading the data -
   [#5476](https://github.com/flutter/devtools/pull/5476)
 
+  修复了响应或请求标签页上的复制按钮
+  在数据仍在加载时即可复制的 UI 问题 -
+  [#5476](https://github.com/flutter/devtools/pull/5476)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.22.2...v2.23.1).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.22.2...v2.23.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.24.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.24.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.24.0 release notes
-shortTitle: 2.24.0 release notes
+# title: DevTools 2.24.0 release notes
+title: DevTools 2.24.0 版本说明
+# shortTitle: 2.24.0 release notes
+shortTitle: 2.24.0 版本说明
 breadcrumb: 2.24.0
-description: Release notes for Dart and Flutter DevTools version 2.24.0.
+# description: Release notes for Dart and Flutter DevTools version 2.24.0.
+description: Dart 和 Flutter DevTools 2.24.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.24.0 release of the Dart and Flutter DevTools
@@ -11,41 +15,86 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.24.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Improve the overall performance of DevTools tables -
   [#5664](https://github.com/flutter/devtools/pull/5664),
   [#5696](https://github.com/flutter/devtools/pull/5696)
 
+  改进了 DevTools 表格的整体性能 -
+  [#5664](https://github.com/flutter/devtools/pull/5664),
+  [#5696](https://github.com/flutter/devtools/pull/5696)
+
 ## CPU profiler updates
+
+## CPU 性能分析器更新
 
 * Fix bug with CPU flame chart selection and tooltips -
   [#5676](https://github.com/flutter/devtools/pull/5676)
 
+  修复了 CPU 火焰图选择和工具提示的 bug -
+  [#5676](https://github.com/flutter/devtools/pull/5676)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Improve support for inspecting
   `UserTag` and `MirrorReferent` instances -
   [#5490](https://github.com/flutter/devtools/pull/5490)
+
+  改进了检查 `UserTag` 和 `MirrorReferent` 实例的支持 -
+  [#5490](https://github.com/flutter/devtools/pull/5490)
 * Fix expression evaluation bug where
   selecting an autocomplete result for a field would clear the current input -
+  [#5717](https://github.com/flutter/devtools/pull/5717)
+
+  修复了表达式求值 bug：选择字段的自动补全结果会清除当前输入 -
   [#5717](https://github.com/flutter/devtools/pull/5717)
 * Make selection of a stack frame
   scroll to the frame location in the source code -
   [#5722](https://github.com/flutter/devtools/pull/5722)
+
+  选择堆栈帧时自动滚动到源代码中的帧位置 -
+  [#5722](https://github.com/flutter/devtools/pull/5722)
 * Improve performance of searching for a file and searching in a file -
+  [#5733](https://github.com/flutter/devtools/pull/5733)
+
+  改进了搜索文件和在文件中搜索的性能 -
   [#5733](https://github.com/flutter/devtools/pull/5733)
 * Disable syntax highlighting for files with more than 100,000 characters
   due to performance constraints -
   [#5743](https://github.com/flutter/devtools/pull/5743)
+
+  由于性能限制，对超过 100,000 个字符的文件禁用语法高亮 -
+  [#5743](https://github.com/flutter/devtools/pull/5743)
 * Fix bug where source code wasn't visible if
   syntax highlighting for a file was disabled -
+  [#5743](https://github.com/flutter/devtools/pull/5743)
+
+  修复了文件语法高亮被禁用时源代码不可见的 bug -
   [#5743](https://github.com/flutter/devtools/pull/5743)
 * Prevent file names and source code from getting out of sync -
   [#5827](https://github.com/flutter/devtools/pull/5827)
 
+  防止文件名和源代码不同步 -
+  [#5827](https://github.com/flutter/devtools/pull/5827)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.23.1...v2.24.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.23.1...v2.24.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.25.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.25.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.25.0 release notes
-shortTitle: 2.25.0 release notes
+# title: DevTools 2.25.0 release notes
+title: DevTools 2.25.0 版本说明
+# shortTitle: 2.25.0 release notes
+shortTitle: 2.25.0 版本说明
 breadcrumb: 2.25.0
-description: Release notes for Dart and Flutter DevTools version 2.25.0.
+# description: Release notes for Dart and Flutter DevTools version 2.25.0.
+description: Dart 和 Flutter DevTools 2.25.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.25.0 release of the Dart and Flutter DevTools
@@ -11,24 +15,51 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.25.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
 
+## 常规更新
+
 - Improve DevTools tab bar navigation when the list of tabs is long -
+  [#5875](https://github.com/flutter/devtools/pull/5875)
+
+  改进了标签页列表较长时的 DevTools 标签栏导航 -
   [#5875](https://github.com/flutter/devtools/pull/5875)
 - Clear registered service methods between app connections -
   [#5960](https://github.com/flutter/devtools/pull/5960)
 
+  在应用连接之间清除已注册的服务方法 -
+  [#5960](https://github.com/flutter/devtools/pull/5960)
+
 ## Memory updates
+
+## 内存更新
 
 - Add legend for class types -
   [#5937](https://github.com/flutter/devtools/pull/5937)
+
+  为类类型添加了图例 -
+  [#5937](https://github.com/flutter/devtools/pull/5937)
 - Enable sampling for Memory > Profile -
+  [#5947](https://github.com/flutter/devtools/pull/5947)
+
+  为 Memory > Profile 启用了采样 -
   [#5947](https://github.com/flutter/devtools/pull/5947)
 
   ![memory sampling](/assets/images/docs/tools/devtools/release-notes/images-2.25.0/memory.png "memory_sampling")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.24.0...v2.25.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.24.0...v2.25.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.26.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.26.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.26.1 release notes
-shortTitle: 2.26.1 release notes
+# title: DevTools 2.26.1 release notes
+title: DevTools 2.26.1 版本说明
+# shortTitle: 2.26.1 release notes
+shortTitle: 2.26.1 版本说明
 breadcrumb: 2.26.1
-description: Release notes for Dart and Flutter DevTools version 2.26.1.
+# description: Release notes for Dart and Flutter DevTools version 2.26.1.
+description: Dart 和 Flutter DevTools 2.26.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.26.1 release of the Dart and Flutter DevTools
@@ -11,7 +15,14 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.26.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 - Added a new "Home" screen in DevTools that either shows the "Connect" dialog
   or a summary of your connected app, depending on
@@ -21,33 +32,69 @@ To learn more about DevTools, check out the
   (tools that don't require a connected app) in DevTools -
   [#6010](https://github.com/flutter/devtools/pull/6010)
 
+  在 DevTools 中添加了新的「Home」屏幕，
+  根据 DevTools 中的连接状态，
+  显示「Connect」对话框或已连接应用的摘要。
+  请关注此屏幕，未来将有更多酷炫的新功能。
+  此更改还启用了对静态工具
+  （不需要连接应用的工具）的支持 -
+  [#6010](https://github.com/flutter/devtools/pull/6010)
+
   ![home screen](/assets/images/docs/tools/devtools/release-notes/images-2.26.1/home_screen.png "DevTools home screen")
 
 - Fixed overlay notifications so that they
   cover the area that their background blocks -
   [#5975](https://github.com/flutter/devtools/pull/5975)
 
+  修复了叠加通知，使其覆盖背景遮挡的区域 -
+  [#5975](https://github.com/flutter/devtools/pull/5975)
+
 ## Memory updates
 
+## 内存更新
+
 - Added a context menu to rename or delete a heap snapshot from the list -
+  [#5997](https://github.com/flutter/devtools/pull/5997)
+
+  添加了上下文菜单，用于从列表中重命名或删除堆快照 -
   [#5997](https://github.com/flutter/devtools/pull/5997)
 - Warn users when HTTP logging may be affecting their app's memory consumption -
   [#5998](https://github.com/flutter/devtools/pull/5998)
 
+  当 HTTP 日志记录可能影响应用内存消耗时警告用户 -
+  [#5998](https://github.com/flutter/devtools/pull/5998)
+
 ## Debugger updates
+
+## 调试器更新
 
 - Improvements to text selection and copy behavior in
   the code view, console, and variables windows -
   [#6020](https://github.com/flutter/devtools/pull/6020)
 
+  改进了代码视图、控制台和变量窗口中的文本选择和复制行为 -
+  [#6020](https://github.com/flutter/devtools/pull/6020)
+
 ## Network profiler updates
+
+## 网络性能分析器更新
 
 - Added a selector to customize the display type
   of text and json responses (thanks to @hhacker1999!) -
   [#5816](https://github.com/flutter/devtools/pull/5816)
 
+  添加了选择器，用于自定义文本和 json 响应的显示类型
+  （感谢 @hhacker1999！）-
+  [#5816](https://github.com/flutter/devtools/pull/5816)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.25.0...v2.26.1).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.25.0...v2.26.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.27.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.27.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.27.0 release notes
-shortTitle: 2.27.0 release notes
+# title: DevTools 2.27.0 release notes
+title: DevTools 2.27.0 版本说明
+# shortTitle: 2.27.0 release notes
+shortTitle: 2.27.0 版本说明
 breadcrumb: 2.27.0
-description: Release notes for Dart and Flutter DevTools version 2.27.0.
+# description: Release notes for Dart and Flutter DevTools version 2.27.0.
+description: Dart 和 Flutter DevTools 2.27.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.27.0 release of the Dart and Flutter DevTools
@@ -11,15 +15,31 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.27.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Network profiler updates
 
+## 网络性能分析器更新
+
 - Fix a crash with large text in network requests and responses -
+  [#6254](https://github.com/flutter/devtools/pull/6254)
+
+  修复了网络请求和响应中大文本导致的崩溃 -
   [#6254](https://github.com/flutter/devtools/pull/6254)
 
   ![Example truncation of text in the network view](/assets/images/docs/tools/devtools/release-notes/images-2.27.0/truncation.png "Example truncation of text in the network view")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.26.1...v2.27.0).
+
+要查看自上一版本以来的完整更改列表，
+请查看
+[GitHub 上的 diff](https://github.com/flutter/devtools/compare/v2.26.1...v2.27.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.28.1 release notes
-shortTitle: 2.28.1 release notes
+# title: DevTools 2.28.1 release notes
+title: DevTools 2.28.1 版本说明
+# shortTitle: 2.28.1 release notes
+shortTitle: 2.28.1 版本说明
 breadcrumb: 2.28.1
-description: Release notes for Dart and Flutter DevTools version 2.28.1.
+# description: Release notes for Dart and Flutter DevTools version 2.28.1.
+description: Dart 和 Flutter DevTools 2.28.1 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.28.1 release of the Dart and Flutter DevTools
@@ -11,7 +15,14 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.28.1 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Added support for DevTools extensions.
   This means if you are debugging an app that depends on `package:foo`,
@@ -22,35 +33,76 @@ To learn more about DevTools, check out the
   check out the getting started guide for
   [package:devtools_extensions](https://pub.dev/packages/devtools_extensions)!
 
+  添加了 DevTools 扩展支持。
+  这意味着如果你正在调试依赖 `package:foo` 的应用，
+  且 `package:foo` 提供了 DevTools 扩展，
+  你将在 DevTools 中看到显示的「Foo」标签页，
+  可以用它来调试你的应用。
+  要为你的 pub package 提供 DevTools 扩展，
+  请查看
+  [package:devtools_extensions](https://pub.dev/packages/devtools_extensions)
+  的入门指南！
+
 ![Example DevTools extension](/assets/images/docs/tools/devtools/release-notes/images-2.28.1/example_devtools_extension.png "Example DevTools extension for package:foo_package")
 
 * Fixed theming bug in isolate selector -
   [#6403](https://github.com/flutter/devtools/pull/6403)
+
+  修复了 isolate 选择器中的主题 bug -
+  [#6403](https://github.com/flutter/devtools/pull/6403)
 * Fixed isolate bug where main isolate was not reselecting on hot restart -
   [#6436](https://github.com/flutter/devtools/pull/6436)
+
+  修复了热重启时 main isolate 未重新选择的 bug -
+  [#6436](https://github.com/flutter/devtools/pull/6436)
 * Show the hot reload button for Dart server apps that support hot reload -
+  [#6341](https://github.com/flutter/devtools/pull/6341)
+
+  为支持热重载的 Dart server 应用显示热重载按钮 -
   [#6341](https://github.com/flutter/devtools/pull/6341)
 * Fixed exceptions on hot restart -
   [#6451](https://github.com/flutter/devtools/pull/6451),
   [#6450](https://github.com/flutter/devtools/pull/6450)
 
+  修复了热重启时的异常 -
+  [#6451](https://github.com/flutter/devtools/pull/6451),
+  [#6450](https://github.com/flutter/devtools/pull/6450)
+
 ## Inspector updates
+
+## 检查器更新
 
 * Fixed bug where inspector service calls were done on the selected isolate,
   instead of the main isolate -
   [#6434](https://github.com/flutter/devtools/pull/6434)
 
+  修复了检查器服务调用在选定的 isolate 而非 main isolate 上执行的 bug -
+  [#6434](https://github.com/flutter/devtools/pull/6434)
+
 ## Logging updates
+
+## 日志更新
 
 * Improved responsiveness of the top bar on the Logging view -
   [#6281](https://github.com/flutter/devtools/pull/6281)
 
+  改进了 Logging 视图顶部栏的响应速度 -
+  [#6281](https://github.com/flutter/devtools/pull/6281)
+
 * Added the ability to copy filtered logs -
+  [#6260](https://github.com/flutter/devtools/pull/6260)
+
+  添加了复制已过滤日志的功能 -
   [#6260](https://github.com/flutter/devtools/pull/6260)
 
   ![The copy button on the Logging view to the right of the filter tool](/assets/images/docs/tools/devtools/release-notes/images-2.28.1/logger_copy.png "The Logging view copy button")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.28.1).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.28.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.28.2 release notes
-shortTitle: 2.28.2 release notes
+# title: DevTools 2.28.2 release notes
+title: DevTools 2.28.2 版本说明
+# shortTitle: 2.28.2 release notes
+shortTitle: 2.28.2 版本说明
 breadcrumb: 2.28.2
-description: Release notes for Dart and Flutter DevTools version 2.28.2.
+# description: Release notes for Dart and Flutter DevTools version 2.28.2.
+description: Dart 和 Flutter DevTools 2.28.2 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.28.2 release of the Dart and Flutter DevTools
@@ -11,18 +15,39 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.28.2 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 This was a cherry-pick release on top of DevTools 2.28.1.
 To learn about the improvements included in DevTools 2.28.1, please read the
 [release notes](/tools/devtools/release-notes/release-notes-2.28.1).
 
+这是在 DevTools 2.28.1 之上的 cherry-pick 版本。
+要了解 DevTools 2.28.1 中包含的改进，请阅读
+[版本说明](/tools/devtools/release-notes/release-notes-2.28.1)。
+
 ## DevTools Extension updates
+
+## DevTools 扩展更新
 
 * Enabled DevTools extensions when debugging a Dart entry point that is not
   under `lib` (e.g. a unit test or integration test). Thanks to
   [@bartekpacia](https://github.com/bartekpacia) for this change! -
   [#6644](https://github.com/flutter/devtools/pull/6644)
 
+  在调试不在 `lib` 下的 Dart 入口点
+  （例如单元测试或集成测试）时启用了 DevTools 扩展。
+  感谢 [@bartekpacia](https://github.com/bartekpacia) 的此项更改！-
+  [#6644](https://github.com/flutter/devtools/pull/6644)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.28.2).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.28.2)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.3.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.3.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.28.3 release notes
-shortTitle: 2.28.3 release notes
+# title: DevTools 2.28.3 release notes
+title: DevTools 2.28.3 版本说明
+# shortTitle: 2.28.3 release notes
+shortTitle: 2.28.3 版本说明
 breadcrumb: 2.28.3
-description: Release notes for Dart and Flutter DevTools version 2.28.3.
+# description: Release notes for Dart and Flutter DevTools version 2.28.3.
+description: Dart 和 Flutter DevTools 2.28.3 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.28.3 release of the Dart and Flutter DevTools
@@ -11,32 +15,64 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.28.3 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 This was a cherry-pick release on top of DevTools 2.28.2.
 To learn about the improvements included in DevTools 2.28.2, please read the
 [release notes](/tools/devtools/release-notes/release-notes-2.28.2).
 
+这是在 DevTools 2.28.2 之上的 cherry-pick 版本。
+要了解 DevTools 2.28.2 中包含的改进，请阅读
+[版本说明](/tools/devtools/release-notes/release-notes-2.28.2)。
+
 ## General updates
+
+## 常规更新
 
 * Added a link to the new "Dive in to DevTools" YouTube
   [video](https://www.youtube.com/watch?v=_EYk-E29edo) in the bottom status bar.
   This video provides a brief tutorial for each DevTools screen.
   [#6554](https://github.com/flutter/devtools/pull/6554)
 
+  在底部状态栏中添加了指向新「Dive in to DevTools」YouTube
+  [视频](https://www.youtube.com/watch?v=_EYk-E29edo) 的链接。
+  该视频为每个 DevTools 屏幕提供了简要教程。
+  [#6554](https://github.com/flutter/devtools/pull/6554)
+
   ![Link to watch a DevTools tutorial video](/assets/images/docs/tools/devtools/release-notes/images-2.28.3/watch_tutorial_link.png "Link to watch a DevTools tutorial video")
 
 * Added a workaround to fix copy button functionality in VSCode. - [#6598](https://github.com/flutter/devtools/pull/6598)
 
+  添加了变通方案以修复 VSCode 中的复制按钮功能。- [#6598](https://github.com/flutter/devtools/pull/6598)
+
 ## Performance updates
+
+## 性能更新
 
 * Disable the Raster Stats tool for the Impeller backend
   since it is not supported. - [#6616](https://github.com/flutter/devtools/pull/6616)
 
+  由于不支持，为 Impeller 后端禁用了 Raster Stats 工具。- [#6616](https://github.com/flutter/devtools/pull/6616)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * When using VS Code with a light theme, the embedded sidebar provided by
   DevTools will now also show in the light theme. - [#6581](https://github.com/flutter/devtools/pull/6581)
 
+  使用浅色主题的 VS Code 时，DevTools 提供的嵌入式侧边栏
+  现在也会以浅色主题显示。- [#6581](https://github.com/flutter/devtools/pull/6581)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.28.3).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.28.3)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.4.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.4.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.28.4 release notes
-shortTitle: 2.28.4 release notes
+# title: DevTools 2.28.4 release notes
+title: DevTools 2.28.4 版本说明
+# shortTitle: 2.28.4 release notes
+shortTitle: 2.28.4 版本说明
 breadcrumb: 2.28.4
-description: Release notes for Dart and Flutter DevTools version 2.28.4.
+# description: Release notes for Dart and Flutter DevTools version 2.28.4.
+description: Dart 和 Flutter DevTools 2.28.4 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.28.4 release of the Dart and Flutter DevTools
@@ -11,18 +15,39 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.28.4 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 This was a cherry-pick release on top of DevTools 2.28.3.
 To learn about the improvements included in DevTools 2.28.3, please read the
 [release notes](/tools/devtools/release-notes/release-notes-2.28.3).
 
+这是在 DevTools 2.28.3 之上的 cherry-pick 版本。
+要了解 DevTools 2.28.3 中包含的改进，请阅读
+[版本说明](/tools/devtools/release-notes/release-notes-2.28.3)。
+
 ## Inspector updates
 
+## 检查器更新
+
 * Added link to package directory documentation, from the inspect settings dialog - [#6825](https://github.com/flutter/devtools/pull/6825)
+
+  从检查器设置对话框中添加了指向 package 目录文档的链接 - [#6825](https://github.com/flutter/devtools/pull/6825)
 
 * Fixed a bug where widgets owned by the Flutter framework were showing up in the widget tree view -
   [#6857](https://github.com/flutter/devtools/pull/6857)
 
+  修复了 Flutter 框架拥有的 widget 出现在 widget 树视图中的 bug -
+  [#6857](https://github.com/flutter/devtools/pull/6857)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.28.4).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.28.4)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.5.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.28.5.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.28.5 release notes
-shortTitle: 2.28.5 release notes
+# title: DevTools 2.28.5 release notes
+title: DevTools 2.28.5 版本说明
+# shortTitle: 2.28.5 release notes
+shortTitle: 2.28.5 版本说明
 breadcrumb: 2.28.5
-description: Release notes for Dart and Flutter DevTools version 2.28.5.
+# description: Release notes for Dart and Flutter DevTools version 2.28.5.
+description: Dart 和 Flutter DevTools 2.28.5 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.28.5 release of the Dart and Flutter DevTools
@@ -11,21 +15,45 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.28.5 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 This was a cherry-pick release on top of DevTools 2.28.4.
 To learn about the improvements included in DevTools 2.28.4, please read the
 [release notes](/tools/devtools/release-notes/release-notes-2.28.4).
 
+这是在 DevTools 2.28.4 之上的 cherry-pick 版本。
+要了解 DevTools 2.28.4 中包含的改进，请阅读
+[版本说明](/tools/devtools/release-notes/release-notes-2.28.4)。
+
 ## Inspector updates
+
+## 检查器更新
 
 * Only cache pub root directories added by the user. - [#6897](https://github.com/flutter/devtools/pull/6897)
 
+  仅缓存用户添加的 pub 根目录。- [#6897](https://github.com/flutter/devtools/pull/6897)
+
 * Remove Flutter pub root if it was accidentally cached. - [#6911](https://github.com/flutter/devtools/pull/6911)
+
+  如果 Flutter pub 根目录被意外缓存，则将其移除。- [#6911](https://github.com/flutter/devtools/pull/6911)
 
 ## DevTools Extension updates
 
+## DevTools 扩展更新
+
 * Fixed a couple bugs preventing Dart server apps from connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982), [#6993](https://github.com/flutter/devtools/pull/6993)
+
+  修复了阻止 Dart server 应用连接到 DevTools 扩展的几个 bug。- [#6982](https://github.com/flutter/devtools/pull/6982), [#6993](https://github.com/flutter/devtools/pull/6993)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.28.5).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.28.5)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.29.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.29.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.29.0 release notes
-shortTitle: 2.29.0 release notes
+# title: DevTools 2.29.0 release notes
+title: DevTools 2.29.0 版本说明
+# shortTitle: 2.29.0 release notes
+shortTitle: 2.29.0 版本说明
 breadcrumb: 2.29.0
-description: Release notes for Dart and Flutter DevTools version 2.29.0.
+# description: Release notes for Dart and Flutter DevTools version 2.29.0.
+description: Dart 和 Flutter DevTools 2.29.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.29.0 release of the Dart and Flutter DevTools
@@ -11,19 +15,37 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.29.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Fix a bug with service extension states not
   being cleared on app disconnect. - [#6547](https://github.com/flutter/devtools/pull/6547)
 
+  修复了应用断开连接时服务扩展状态未清除的 bug。- [#6547](https://github.com/flutter/devtools/pull/6547)
+
 * Improved styling of bottom status bar when connected to an app. - [#6525](https://github.com/flutter/devtools/pull/6525)
+
+  改进了连接到应用时底部状态栏的样式。- [#6525](https://github.com/flutter/devtools/pull/6525)
 
 * Added a workaround to fix copy button functionality in VSCode. - [#6598](https://github.com/flutter/devtools/pull/6598)
 
+  添加了变通方案以修复 VSCode 中的复制按钮功能。- [#6598](https://github.com/flutter/devtools/pull/6598)
+
 ## Performance updates
+
+## 性能更新
 
 * Added an option in the "Enhance Tracing" menu for tracking platform channel
   activity. This is useful for apps with plugins. - [#6515](https://github.com/flutter/devtools/pull/6515)
+
+  在「Enhance Tracing」菜单中添加了追踪 platform channel
+  活动的选项。这对使用插件的应用很有用。- [#6515](https://github.com/flutter/devtools/pull/6515)
 
   ![Track platform channels setting](/assets/images/docs/tools/devtools/release-notes/images-2.29.0/track_platform_channels.png "Track platform channels setting")
 
@@ -31,28 +53,55 @@ To learn more about DevTools, check out the
   Performance data that was previously saved from DevTools can be
   reloaded for viewing from this screen. - [#6567](https://github.com/flutter/devtools/pull/6567)
 
+  在没有连接应用时也可使用 Performance 屏幕。
+  之前从 DevTools 保存的性能数据可以
+  从此屏幕重新加载查看。- [#6567](https://github.com/flutter/devtools/pull/6567)
+
 * Added an "Open" button to the Performance controls for
   loading data that was previously saved from DevTools. - [#6567](https://github.com/flutter/devtools/pull/6567)
+
+  在 Performance 控件中添加了「Open」按钮，
+  用于加载之前从 DevTools 保存的数据。- [#6567](https://github.com/flutter/devtools/pull/6567)
 
   ![Open file button on the performance screen](/assets/images/docs/tools/devtools/release-notes/images-2.29.0/open_file_performance_screen.png "Open file button on the performance screen")
 
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Tree guidelines are now always enabled for the
   "Bottom Up" and "Call Tree" tabs. - [#6534](https://github.com/flutter/devtools/pull/6534)
+
+  「Bottom Up」和「Call Tree」标签页现在始终启用树形参考线。- [#6534](https://github.com/flutter/devtools/pull/6534)
 
 * Made the CPU profiler screen available when there is no connected app.
   CPU profiles that were previously saved from DevTools can be
   reloaded for viewing from this screen. - [#6567](https://github.com/flutter/devtools/pull/6567)
 
+  在没有连接应用时也可使用 CPU 性能分析器屏幕。
+  之前从 DevTools 保存的 CPU 性能分析配置可以
+  从此屏幕重新加载查看。- [#6567](https://github.com/flutter/devtools/pull/6567)
+
 * Added an "Open" button to the CPU profiler controls for loading data that
   was previously saved from DevTools. - [#6567](https://github.com/flutter/devtools/pull/6567)
 
+  在 CPU 性能分析器控件中添加了「Open」按钮，
+  用于加载之前从 DevTools 保存的数据。- [#6567](https://github.com/flutter/devtools/pull/6567)
+
 ## Network profiler updates
+
+## 网络性能分析器更新
 
 * Network statuses now show with an error color when the request failed. - [#6527](https://github.com/flutter/devtools/pull/6527)
 
+  请求失败时，网络状态现在以错误颜色显示。- [#6527](https://github.com/flutter/devtools/pull/6527)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.29.0).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.29.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.30.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.30.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.30.0 release notes
-shortTitle: 2.30.0 release notes
+# title: DevTools 2.30.0 release notes
+title: DevTools 2.30.0 版本说明
+# shortTitle: 2.30.0 release notes
+shortTitle: 2.30.0 版本说明
 breadcrumb: 2.30.0
-description: Release notes for Dart and Flutter DevTools version 2.30.0.
+# description: Release notes for Dart and Flutter DevTools version 2.30.0.
+description: Dart 和 Flutter DevTools 2.30.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.30.0 release of the Dart and Flutter DevTools
@@ -11,9 +15,19 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.30.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Performance updates
 
+## 性能更新
+
 * Add an indicator of the rendering engine to the Flutter Frames chart. -
+  [#6771](https://github.com/flutter/devtools/pull/6771)
+
+  在 Flutter Frames 图表中添加了渲染引擎指示器。-
   [#6771](https://github.com/flutter/devtools/pull/6771)
 
   ![Flutter rendering engine text](/assets/images/docs/tools/devtools/release-notes/images-2.30.0/flutter_frames_engine_text.png "Text describing the current flutter rendering engine")
@@ -21,18 +35,35 @@ To learn more about DevTools, check out the
 * Improve messaging when we do not have analysis data available for a
   Flutter frame. - [#6768](https://github.com/flutter/devtools/pull/6768)
 
+  改进了 Flutter 帧没有可用分析数据时的提示信息。- [#6768](https://github.com/flutter/devtools/pull/6768)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * The Flutter Sidebar provided to VS Code now has the ability to enable new
   platforms if a device is available for a platform that is not enabled for
   the current project. This also requires a corresponding Dart extension for
   VS Code update to appear. - [#6688](https://github.com/flutter/devtools/pull/6688)
 
+  提供给 VS Code 的 Flutter 侧边栏现在可以在
+  当前项目未启用的平台有可用设备时启用新平台。
+  这也需要相应的 VS Code Dart 扩展更新才能显示。- [#6688](https://github.com/flutter/devtools/pull/6688)
+
 * The DevTools menu in the sidebar now has an entry "Open in Browser"
   that opens DevTools in an external browser window even when VS Code settings
   are set to usually use embedded DevTools. - [#6736](https://github.com/flutter/devtools/pull/6736)
 
+  侧边栏中的 DevTools 菜单现在有一个「Open in Browser」条目，
+  即使 VS Code 设置通常使用嵌入式 DevTools，
+  也会在外部浏览器窗口中打开 DevTools。- [#6736](https://github.com/flutter/devtools/pull/6736)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.30.0).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.30.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.31.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.31.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.31.0 release notes
-shortTitle: 2.31.0 release notes
+# title: DevTools 2.31.0 release notes
+title: DevTools 2.31.0 版本说明
+# shortTitle: 2.31.0 release notes
+shortTitle: 2.31.0 版本说明
 breadcrumb: 2.31.0
-description: Release notes for Dart and Flutter DevTools version 2.31.0.
+# description: Release notes for Dart and Flutter DevTools version 2.31.0.
+description: Dart 和 Flutter DevTools 2.31.0 版本的发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.31.0 release of the Dart and Flutter DevTools
@@ -11,58 +15,116 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 2.31.0 版本
+在各项常规改进之外，还包含以下更改。
+要了解更多 DevTools 信息，请参阅
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Added a new feature for deep link validation,
   supporting deep link web checks on Android. - [#6935](https://github.com/flutter/devtools/pull/6935)
+
+  添加了深度链接验证的新功能，
+  支持在 Android 上进行深度链接 Web 检查。- [#6935](https://github.com/flutter/devtools/pull/6935)
 * Added the basic plumbing to allow connections to a Dart Tooling Daemon. - [#7009](https://github.com/flutter/devtools/pull/7009)
+
+  添加了连接到 Dart Tooling Daemon 的基本基础架构。- [#7009](https://github.com/flutter/devtools/pull/7009)
 * Made table text selectable [#6919](https://github.com/flutter/devtools/pull/6919)
+
+  使表格文本可选择 [#6919](https://github.com/flutter/devtools/pull/6919)
 
 ## Inspector updates
 
+## 检查器更新
+
 * When done typing in the search field, the
   next selection is now automatically selected - [#6677](https://github.com/flutter/devtools/pull/6677)
+
+  在搜索字段中输入完成后，
+  现在会自动选择下一项 - [#6677](https://github.com/flutter/devtools/pull/6677)
 * Added link to package directory documentation,
   from the inspect settings dialog - [#6825](https://github.com/flutter/devtools/pull/6825)
+
+  从检查器设置对话框中添加了指向 package 目录文档的链接 - [#6825](https://github.com/flutter/devtools/pull/6825)
 
   ![Link to documentation](/assets/images/docs/tools/devtools/release-notes/images-2.31.0/link-to-doc.png "Link to documentation")
 
 * Fix bug where widgets owned by the Flutter framework were
   showing up in the widget tree view - [#6857](https://github.com/flutter/devtools/pull/6857)
+
+  修复了 Flutter 框架拥有的 widget 出现在 widget 树视图中的 bug - [#6857](https://github.com/flutter/devtools/pull/6857)
 * Only cache pub root directories added by the user - [#6897](https://github.com/flutter/devtools/pull/6897)
+
+  仅缓存用户添加的 pub 根目录 - [#6897](https://github.com/flutter/devtools/pull/6897)
 * Remove Flutter pub root if it was accidentally cached - [#6911](https://github.com/flutter/devtools/pull/6911)
+
+  如果 Flutter pub 根目录被意外缓存，则将其移除 - [#6911](https://github.com/flutter/devtools/pull/6911)
 
 ## Performance updates
 
+## 性能更新
+
 * Changed raster layer preview background to a checkerboard. - [#6827](https://github.com/flutter/devtools/pull/6827)
+
+  将光栅图层预览背景更改为棋盘格。- [#6827](https://github.com/flutter/devtools/pull/6827)
 
 ## CPU profiler updates
 
+## CPU 性能分析器更新
+
 * Added hover cards to show sampling rate for the item in drop down. - [#7010](https://github.com/flutter/devtools/pull/7010)
+
+  添加了悬停卡片，显示下拉列表中项目的采样率。- [#7010](https://github.com/flutter/devtools/pull/7010)
 
   ![Sampling rate for dropdown](/assets/images/docs/tools/devtools/release-notes/images-2.31.0/hover-for-dropdown.png "Sampling rate for dropdown")
 
 ## Debugger updates
 
+## 调试器更新
+
 * Highlight `extension type` as a declaration keyword,
   highlight the `$` in identifier interpolation as part of the interpolation,
   and properly highlight comments within type arguments. - [6837](https://github.com/flutter/devtools/pull/6837)
 
+  将 `extension type` 高亮为声明关键字，
+  将标识符插值中的 `$` 高亮为插值的一部分，
+  并正确高亮类型参数中的注释。- [6837](https://github.com/flutter/devtools/pull/6837)
+
 ## Logging updates
+
+## 日志更新
 
 * Added scrollbar to details pane. - [#6917](https://github.com/flutter/devtools/pull/6917)
 
+  为详细信息窗格添加了滚动条。- [#6917](https://github.com/flutter/devtools/pull/6917)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * Fixed an issue that prevented the VS code sidebar from
   loading in recent beta/master builds. - [#6984](https://github.com/flutter/devtools/pull/6984)
 
+  修复了阻止 VS Code 侧边栏在最近的 beta/master 构建中加载的问题。- [#6984](https://github.com/flutter/devtools/pull/6984)
+
 ## DevTools Extension updates
+
+## DevTools 扩展更新
 
 * Fixed a couple bugs preventing Dart server apps from
   connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982), [#6993](https://github.com/flutter/devtools/pull/6993)
 
+  修复了阻止 Dart server 应用连接到 DevTools 扩展的几个 bug。- [#6982](https://github.com/flutter/devtools/pull/6982), [#6993](https://github.com/flutter/devtools/pull/6993)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.31.0).
+
+要查看此版本中的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.31.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.32.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.32.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.32.0 release notes
-shortTitle: 2.32.0 release notes
+# title: DevTools 2.32.0 release notes
+title: DevTools 2.32.0 发布说明
+# shortTitle: 2.32.0 release notes
+shortTitle: 2.32.0 发布说明
 breadcrumb: 2.32.0
-description: Release notes for Dart and Flutter DevTools version 2.32.0.
+# description: Release notes for Dart and Flutter DevTools version 2.32.0.
+description: Dart 和 Flutter DevTools 2.32.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.32.0 release of the Dart and Flutter DevTools
@@ -11,55 +15,110 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.32.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Improved overall usability by making the DevTools UI more dense.
   This significantly improves the user experience when using
   DevTools embedded in an IDE. - [#7030](https://github.com/flutter/devtools/pull/7030)
+
+  通过让 DevTools UI 更加紧凑来提升整体可用性。
+  这显著改善了在 IDE 中嵌入使用 DevTools 时的用户体验。- [#7030](https://github.com/flutter/devtools/pull/7030)
 * Removed the "Dense mode" setting. - [#7086](https://github.com/flutter/devtools/pull/7086)
+
+  移除了「Dense mode」设置。- [#7086](https://github.com/flutter/devtools/pull/7086)
 * Added support for filtering with regular expressions in the
   Logging, Network, and CPU profiler pages - [#7027](https://github.com/flutter/devtools/pull/7027)
+
+  在 Logging、Network 和 CPU profiler 页面中添加了使用正则表达式进行过滤的支持 - [#7027](https://github.com/flutter/devtools/pull/7027)
 * Add a DevTools server interaction for getting the DTD uri. - [#7054](https://github.com/flutter/devtools/pull/7054)
+
+  添加了用于获取 DTD uri 的 DevTools 服务器交互。- [#7054](https://github.com/flutter/devtools/pull/7054)
 
 ## Memory updates
 
+## 内存更新
+
 * Supported allocation tracing for Flutter profile builds and
   Dart AOT compiled applications. - [#7058](https://github.com/flutter/devtools/pull/7058)
+
+  支持对 Flutter profile 构建和 Dart AOT 编译应用程序进行分配跟踪。- [#7058](https://github.com/flutter/devtools/pull/7058)
 * Supported import of memory snapshots. - [#6974](https://github.com/flutter/devtools/pull/6974)
 
+  支持导入内存快照。- [#6974](https://github.com/flutter/devtools/pull/6974)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Highlighted `extension type` as a declaration keyword,
   highlight the `$` in identifier interpolation as part of the interpolation,
   and properly highlight comments within type arguments. - [#6837](https://github.com/flutter/devtools/pull/6837)
 
+  将 `extension type` 高亮为声明关键字，
+  将标识符插值中的 `$` 高亮为插值的一部分，
+  并正确高亮类型参数中的注释。- [#6837](https://github.com/flutter/devtools/pull/6837)
+
 ## Logging updates
 
+## 日志更新
+
 * Added toggle filters to filter out noisy Flutter and Dart logs - [#7026](https://github.com/flutter/devtools/pull/7026)
+
+  添加了切换过滤器，用于过滤嘈杂的 Flutter 和 Dart 日志 - [#7026](https://github.com/flutter/devtools/pull/7026)
 
   ![Logging view filters](/assets/images/docs/tools/devtools/release-notes/images-2.32.0/logging_toggle_filters.png "Toggle filters for logging screen")
 
 * Added a scrollbar to the details pane. - [#6917](https://github.com/flutter/devtools/pull/6917)
 
+  在详细信息面板中添加了滚动条。- [#6917](https://github.com/flutter/devtools/pull/6917)
+
 ## DevTools extension updates
+
+## DevTools 扩展更新
 
 * Added a description and documentation link to the `devtools_options.yaml` file
   that is created in a user's project. - [#7052](https://github.com/flutter/devtools/pull/7052)
+
+  为用户项目中创建的 `devtools_options.yaml` 文件添加了描述和文档链接。- [#7052](https://github.com/flutter/devtools/pull/7052)
 * Updated the Simulated DevTools Environment Panel to be collapsible
   (thanks to @victoreronmosele!) - [#7062](https://github.com/flutter/devtools/pull/7062)
+
+  更新了 Simulated DevTools Environment Panel，使其可折叠
+  （感谢 @victoreronmosele！）- [#7062](https://github.com/flutter/devtools/pull/7062)
 * Integrated DevTools extensions with the new Dart Tooling Daemon.
   This will allow DevTools extensions to access public methods registered by
   other DTD clients, such as an IDE, as well as access a minimal file system API
   for interacting with the development project. - [#7108](https://github.com/flutter/devtools/pull/7108)
 
+  将 DevTools 扩展与新的 Dart Tooling Daemon 集成。
+  这让 DevTools 扩展可以访问由其他 DTD 客户端（例如 IDE）注册的公共方法，
+  以及访问用于与开发项目交互的最小文件系统 API。- [#7108](https://github.com/flutter/devtools/pull/7108)
+
 ## VS Code sidebar updates
+
+## VS Code 侧边栏更新
 
 * Fixed an issue that prevented the VS code sidebar from
   loading in recent `beta` and `main` builds. - [#6984](https://github.com/flutter/devtools/pull/6984)
+
+  修复了阻止 VS Code 侧边栏在最近的 `beta` 和 `main` 构建中加载的问题。- [#6984](https://github.com/flutter/devtools/pull/6984)
 * Showed DevTools extensions as an option from the
   debug sessions DevTools dropdown, when available. [#6709](https://github.com/flutter/devtools/pull/6709)
 
+  在可用时，从调试会话的 DevTools 下拉菜单中将 DevTools 扩展显示为一个选项。[#6709](https://github.com/flutter/devtools/pull/6709)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.32.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.32.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.33.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.33.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.33.0 release notes
-shortTitle: 2.33.0 release notes
+# title: DevTools 2.33.0 release notes
+title: DevTools 2.33.0 发布说明
+# shortTitle: 2.33.0 release notes
+shortTitle: 2.33.0 发布说明
 breadcrumb: 2.33.0
-description: Release notes for Dart and Flutter DevTools version 2.33.0.
+# description: Release notes for Dart and Flutter DevTools version 2.33.0.
+description: Dart 和 Flutter DevTools 2.33.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.33.0 release of the Dart and Flutter DevTools
@@ -11,52 +15,111 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.33.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Improved overall usability by making the DevTools UI more dense.
   This significantly improves the user experience when using
   DevTools embedded in an IDE. - [#7030](https://github.com/flutter/devtools/pull/7030)
+
+  通过让 DevTools UI 更加紧凑来提升整体可用性。
+  这显著改善了在 IDE 中嵌入使用 DevTools 时的用户体验。- [#7030](https://github.com/flutter/devtools/pull/7030)
 * Removed the "Dense mode" setting. - [#7086](https://github.com/flutter/devtools/pull/7086)
+
+  移除了「Dense mode」设置。- [#7086](https://github.com/flutter/devtools/pull/7086)
 * Added support for filtering with regular expressions in
   the Logging, Network, and CPU profiler pages. - [#7027](https://github.com/flutter/devtools/pull/7027)
+
+  在 Logging、Network 和 CPU profiler 页面中添加了使用正则表达式进行过滤的支持。- [#7027](https://github.com/flutter/devtools/pull/7027)
 * Add a DevTools server interaction for getting the DTD URI. - [#7054](https://github.com/flutter/devtools/pull/7054), [#7164](https://github.com/flutter/devtools/pull/7164)
+
+  添加了用于获取 DTD URI 的 DevTools 服务器交互。- [#7054](https://github.com/flutter/devtools/pull/7054), [#7164](https://github.com/flutter/devtools/pull/7164)
 * Enabled expression evaluation with scope for the web,
   allowing evaluation of inspected widgets. - [#7144](https://github.com/flutter/devtools/pull/7144)
+
+  为 Web 启用了带作用域的表达式求值，
+  让你可以求值已检查的 widget。- [#7144](https://github.com/flutter/devtools/pull/7144)
 * Update `package:vm_service` constraint to `^14.0.0`. - [#6953](https://github.com/flutter/devtools/pull/6953)
+
+  将 `package:vm_service` 约束更新为 `^14.0.0`。- [#6953](https://github.com/flutter/devtools/pull/6953)
 * Onboarding DevTools to [`package:unified_analytics`](https://pub.dev/packages/unified_analytics) for
   unified telemetry logging across Flutter and Dart tooling. - [#7084](https://github.com/flutter/devtools/pull/7084)
 
+  将 DevTools 接入 [`package:unified_analytics`](https://pub.dev/packages/unified_analytics)，
+  以在 Flutter 和 Dart 工具中实现统一的遥测日志记录。- [#7084](https://github.com/flutter/devtools/pull/7084)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Fixed off by one error causing profiler hits to be
   rendered on the wrong lines. - [#7178](https://github.com/flutter/devtools/pull/7178)
+
+  修复了差一错误，该错误导致 profiler 命中显示在错误的行上。- [#7178](https://github.com/flutter/devtools/pull/7178)
 * Improved contrast of line numbers when
   displaying code coverage hits in dark mode. - [#7178](https://github.com/flutter/devtools/pull/7178)
+
+  改进了在深色模式下显示代码覆盖率命中时的行号对比度。- [#7178](https://github.com/flutter/devtools/pull/7178)
 * Improved contrast of profiling details when
   displaying profiler hits in dark mode. - [#7178](https://github.com/flutter/devtools/pull/7178)
+
+  改进了在深色模式下显示 profiler 命中时的分析详情对比度。- [#7178](https://github.com/flutter/devtools/pull/7178)
 * Fixed syntax highlighting for comments when
   the source file uses `\r\n` line endings [#7190](https://github.com/flutter/devtools/pull/7190)
+
+  修复了源文件使用 `\r\n` 行尾时注释的语法高亮问题 [#7190](https://github.com/flutter/devtools/pull/7190)
 * Re-establish breakpoints after a hot-restart. - [#7205](https://github.com/flutter/devtools/pull/7205)
+
+  在热重启后重新建立断点。- [#7205](https://github.com/flutter/devtools/pull/7205)
 
 ## VS Code Sidebar updates
 
+## VS Code 侧边栏更新
+
 * Do not show DevTools release notes in the Flutter sidebar. - [#7166](https://github.com/flutter/devtools/pull/7166)
+
+  不在 Flutter 侧边栏中显示 DevTools 发布说明。- [#7166](https://github.com/flutter/devtools/pull/7166)
 
 ## DevTools Extension updates
 
+## DevTools 扩展更新
+
 * Added support for connecting to the Dart Tooling Daemon from
   the simulated DevTools environment. - [#7133](https://github.com/flutter/devtools/pull/7133)
+
+  添加了从模拟 DevTools 环境连接到 Dart Tooling Daemon 的支持。- [#7133](https://github.com/flutter/devtools/pull/7133)
 * Added help buttons to the VM Service and DTD connection text fields in
   the simulated DevTools environment. - [#7133](https://github.com/flutter/devtools/pull/7133)
+
+  在模拟 DevTools 环境中的 VM Service 和 DTD 连接文本字段中添加了帮助按钮。- [#7133](https://github.com/flutter/devtools/pull/7133)
 * Fixed an issue with not detecting extensions for
   test files in subdirectories. - [#7174](https://github.com/flutter/devtools/pull/7174)
+
+  修复了无法检测子目录中测试文件的扩展的问题。- [#7174](https://github.com/flutter/devtools/pull/7174)
 * Added an example of creating an extension for a pure Dart package. - [#7196](https://github.com/flutter/devtools/pull/7196)
+
+  添加了为纯 Dart 包创建扩展的示例。- [#7196](https://github.com/flutter/devtools/pull/7196)
 * Updated the `README.md` and `example/README.md` with
   more complete documentation. - [#7237](https://github.com/flutter/devtools/pull/7237), [#7261](https://github.com/flutter/devtools/pull/7261)
+
+  更新了 `README.md` 和 `example/README.md`，提供更完整的文档。- [#7237](https://github.com/flutter/devtools/pull/7237), [#7261](https://github.com/flutter/devtools/pull/7261)
 * Added a `devtools_extensions validate` command to
   validate extension requirements during development. - [#7257](https://github.com/flutter/devtools/pull/7257)
 
+  添加了 `devtools_extensions validate` 命令，
+  用于在开发期间验证扩展要求。- [#7257](https://github.com/flutter/devtools/pull/7257)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.33.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.33.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.34.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.34.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.34.1 release notes
-shortTitle: 2.34.1 release notes
+# title: DevTools 2.34.1 release notes
+title: DevTools 2.34.1 发布说明
+# shortTitle: 2.34.1 release notes
+shortTitle: 2.34.1 发布说明
 breadcrumb: 2.34.1
-description: Release notes for Dart and Flutter DevTools version 2.34.1.
+# description: Release notes for Dart and Flutter DevTools version 2.34.1.
+description: Dart 和 Flutter DevTools 2.34.1 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.34.1 release of the Dart and Flutter DevTools
@@ -11,20 +15,41 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.34.1 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Fixed an issue preventing DevTools from connecting to Flutter apps that
   are not launched from Flutter Tools. - [#6848](https://github.com/flutter/devtools/issues/6848)
+
+  修复了阻止 DevTools 连接到非通过 Flutter Tools 启动的 Flutter 应用的问题。- [#6848](https://github.com/flutter/devtools/issues/6848)
 * Improved performance of the FlatTable. -
+  [#7391](https://github.com/flutter/devtools/pull/7391)
+
+  改进了 FlatTable 的性能。-
   [#7391](https://github.com/flutter/devtools/pull/7391)
 
 ## Inspector updates
 
+## 检查器更新
+
 - Fixes an edge case where widgets from other packages could
   show up in the inspector tree. - [#7353](https://github.com/flutter/devtools/pull/7353)
 
+  修复了一个边缘情况，即来自其他包的 widget 可能出现在检查器树中。- [#7353](https://github.com/flutter/devtools/pull/7353)
+
 ## Performance updates
+
+## 性能更新
+
 * Add a setting to include CPU samples in the Timeline. -
+  [#7333](https://github.com/flutter/devtools/pull/7333), [#7369](https://github.com/flutter/devtools/pull/7369)
+
+  添加了在 Timeline 中包含 CPU 样本的设置。-
   [#7333](https://github.com/flutter/devtools/pull/7333), [#7369](https://github.com/flutter/devtools/pull/7369)
 
   ![Timeline settings](/assets/images/docs/tools/devtools/release-notes/images-2.34.1/7369-timeline-settings.png "Timeline settings")
@@ -34,17 +59,36 @@ To learn more about DevTools, check out the
   embedded Perfetto trace viewer in DevTools version 2.21.1, but was
   available behind a setting to ensure a smooth rollout.
   This release of DevTools removes the legacy trace viewer entirely. - [#7316](https://github.com/flutter/devtools/pull/7316)
+
+  移除了旧版跟踪查看器。
+  旧版跟踪查看器在 DevTools 2.21.1 版本中已被嵌入式 Perfetto 跟踪查看器取代，
+  但可通过设置使用以确保平稳过渡。
+  此版本的 DevTools 完全移除了旧版跟踪查看器。- [#7316](https://github.com/flutter/devtools/pull/7316)
 * Updated the Perfetto trace viewer build. -
+  [#7445](https://github.com/flutter/devtools/pull/7445),
+  [#7456](https://github.com/flutter/devtools/pull/7456),
+  [#7480](https://github.com/flutter/devtools/pull/7480)
+
+  更新了 Perfetto 跟踪查看器构建。-
   [#7445](https://github.com/flutter/devtools/pull/7445),
   [#7456](https://github.com/flutter/devtools/pull/7456),
   [#7480](https://github.com/flutter/devtools/pull/7480)
 * Added a loading message to show when refreshing the timeline. - [#7463](https://github.com/flutter/devtools/pull/7463)
 
+  添加了在刷新时间线时显示的加载消息。- [#7463](https://github.com/flutter/devtools/pull/7463)
+
   ![Loading message](/assets/images/docs/tools/devtools/release-notes/images-2.34.1/7463-overlay.png "Loading message")
 
 ## Memory updates
 
+## 内存更新
+
 * Enabled export of snapshots and improved snapshotting performance. -
+  [#7197](https://github.com/flutter/devtools/pull/7197),
+  [#7439](https://github.com/flutter/devtools/pull/7439),
+  [#7449](https://github.com/flutter/devtools/pull/7449)
+
+  启用了快照导出并改进了快照性能。-
   [#7197](https://github.com/flutter/devtools/pull/7197),
   [#7439](https://github.com/flutter/devtools/pull/7439),
   [#7449](https://github.com/flutter/devtools/pull/7449)
@@ -53,25 +97,48 @@ To learn more about DevTools, check out the
 
 * Fixed failures during disconnect in tracing. - [#7440](https://github.com/flutter/devtools/pull/7440)
 
+  修复了跟踪期间断开连接时的失败问题。- [#7440](https://github.com/flutter/devtools/pull/7440)
+
 * Made class filter shared between
   the panes `Profile Memory` and `Diff Snapshots`. - [#7462](https://github.com/flutter/devtools/pull/7462)
 
+  使 `Profile Memory` 和 `Diff Snapshots` 面板之间共享类过滤器。- [#7462](https://github.com/flutter/devtools/pull/7462)
+
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Improved Network profiler performance. - [#7266](https://github.com/flutter/devtools/pull/7266)
+
+  改进了 Network profiler 性能。- [#7266](https://github.com/flutter/devtools/pull/7266)
 * Fixed a bug where selected pending requests weren't
   refreshing the tab once updated. - [#7266](https://github.com/flutter/devtools/pull/7266)
+
+  修复了一个 bug，即选中的待处理请求在更新后不会刷新标签页。- [#7266](https://github.com/flutter/devtools/pull/7266)
 * Fixed the JSON viewer so multiline strings are visible in their row, and
   through a tooltip. - [#7389](https://github.com/flutter/devtools/pull/7389)
+
+  修复了 JSON 查看器，使多行字符串在其行中以及通过工具提示可见。- [#7389](https://github.com/flutter/devtools/pull/7389)
 * Fixed JsonViewer where all of the
   expanded sections would snap closed. [#7367](https://github.com/flutter/devtools/pull/7367)
 
+  修复了 JsonViewer 中所有展开部分会突然关闭的问题。[#7367](https://github.com/flutter/devtools/pull/7367)
+
 ## Deep Links tool updates
+
+## 深层链接工具更新
 
 * Automatically populate a list of Flutter projects from
   the connected IDE. - [#7415](https://github.com/flutter/devtools/pull/7415), [#7431](https://github.com/flutter/devtools/pull/7431)
 
+  从已连接的 IDE 自动填充 Flutter 项目列表。- [#7415](https://github.com/flutter/devtools/pull/7415), [#7431](https://github.com/flutter/devtools/pull/7431)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.34.1).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.34.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.35.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.35.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.35.0 release notes
-shortTitle: 2.35.0 release notes
+# title: DevTools 2.35.0 release notes
+title: DevTools 2.35.0 发布说明
+# shortTitle: 2.35.0 release notes
+shortTitle: 2.35.0 发布说明
 breadcrumb: 2.35.0
-description: Release notes for Dart and Flutter DevTools version 2.35.0.
+# description: Release notes for Dart and Flutter DevTools version 2.35.0.
+description: Dart 和 Flutter DevTools 2.35.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.35.0 release of the Dart and Flutter DevTools
@@ -11,60 +15,116 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.35.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Changed to a single button for starting and stopping
   recording on the Network screen and CPU profiler screen. - [#7573](https://github.com/flutter/devtools/pull/7573)
+
+  在 Network 屏幕和 CPU profiler 屏幕上改为使用单个按钮来开始和停止录制。- [#7573](https://github.com/flutter/devtools/pull/7573)
 
   ![A screen shot of the CPU profiler tab, with the new recording button.](/assets/images/docs/tools/devtools/release-notes/images-2.35.0/profiler_recording.png)
   ![A screen shot of the network tab, with the new recording button.](/assets/images/docs/tools/devtools/release-notes/images-2.35.0/network_recording.png)
 
 ## Inspector updates
 
+## 检查器更新
+
 * Add a preference for the default inspector view - [#6949](https://github.com/flutter/devtools/pull/6949)
+
+  添加了默认检查器视图的偏好设置 - [#6949](https://github.com/flutter/devtools/pull/6949)
 
 ## Memory updates
 
+## 内存更新
+
 * Replaced total size with reachable size in snapshot list. - [#7493](https://github.com/flutter/devtools/pull/7493)
 
+  在快照列表中用可达大小替换了总大小。- [#7493](https://github.com/flutter/devtools/pull/7493)
+
 ## Debugger updates
+
+## 调试器更新
 
 * During a hot-restart, `pause_isolates_on_start` and only
   `resume` the app once breakpoints are set. - [#7234](https://github.com/flutter/devtools/pull/7234)
 
+  在热重启期间，使用 `pause_isolates_on_start`，并且仅在设置断点后才 `resume` 应用。- [#7234](https://github.com/flutter/devtools/pull/7234)
+
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Added text selection in text viewer for requests and responses. - [#7596](https://github.com/flutter/devtools/pull/7596)
+
+  在请求和响应的文本查看器中添加了文本选择功能。- [#7596](https://github.com/flutter/devtools/pull/7596)
 * Added a JSON copy experience to the JSON viewer. - [#7596](https://github.com/flutter/devtools/pull/7596)
+
+  在 JSON 查看器中添加了 JSON 复制体验。- [#7596](https://github.com/flutter/devtools/pull/7596)
 
   ![The new JSON copy experience in the JSON viewer](/assets/images/docs/tools/devtools/release-notes/images-2.35.0/json_viewer_copy.png)
 
 * Fixed a bug where stopping and starting network recording listed requests that
   happened while not recording. - [#7626](https://github.com/flutter/devtools/pull/7626)
 
+  修复了一个 bug，即在停止和开始网络录制时会列出未录制期间发生的请求。- [#7626](https://github.com/flutter/devtools/pull/7626)
+
 ## Deep links tool updates
 
+## 深层链接工具更新
+
 * Improve layout for narrow screens. - [#7524](https://github.com/flutter/devtools/pull/7524)
+
+  改进了窄屏幕的布局。- [#7524](https://github.com/flutter/devtools/pull/7524)
 * Add error handling for missing schemes and domains - [#7559](https://github.com/flutter/devtools/pull/7559)
 
+  添加了对缺少 scheme 和 domain 的错误处理 - [#7559](https://github.com/flutter/devtools/pull/7559)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * Added a DevTools section with a list of tools and extensions that
   are available without a debug session. -
   [#7598](https://github.com/flutter/devtools/pull/7598), [#7604](https://github.com/flutter/devtools/pull/7604)
 
+  添加了 DevTools 部分，其中列出了无需调试会话即可使用的工具和扩展。-
+  [#7598](https://github.com/flutter/devtools/pull/7598), [#7604](https://github.com/flutter/devtools/pull/7604)
+
 ## DevTools Extension updates
+
+## DevTools 扩展更新
 
 * Support DevTools extensions that do not require a running app, and
   detect them from the user's IDE workspace. - [#7612](https://github.com/flutter/devtools/pull/7612)
+
+  支持不需要运行应用的 DevTools 扩展，
+  并从用户的 IDE 工作区中检测它们。- [#7612](https://github.com/flutter/devtools/pull/7612)
 * Deprecate the `DevToolsExtension.requiresRunningApplication` field in
   favor of the new optional `requiresConnection` field that
   can be added to an extension's `config.yaml` file. -
   [#7611](https://github.com/flutter/devtools/pull/7611), [#7602](https://github.com/flutter/devtools/pull/7602)
+
+  弃用 `DevToolsExtension.requiresRunningApplication` 字段，
+  改用可添加到扩展 `config.yaml` 文件中的新可选 `requiresConnection` 字段。-
+  [#7611](https://github.com/flutter/devtools/pull/7611), [#7602](https://github.com/flutter/devtools/pull/7602)
 * Detect extensions for all types of run targets in a package. -
+  [#7533](https://github.com/flutter/devtools/pull/7533), [#7535](https://github.com/flutter/devtools/pull/7535)
+
+  检测包中所有类型的运行目标的扩展。-
   [#7533](https://github.com/flutter/devtools/pull/7533), [#7535](https://github.com/flutter/devtools/pull/7535)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.35.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.35.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.36.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.36.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.36.0 release notes
-shortTitle: 2.36.0 release notes
+# title: DevTools 2.36.0 release notes
+title: DevTools 2.36.0 发布说明
+# shortTitle: 2.36.0 release notes
+shortTitle: 2.36.0 发布说明
 breadcrumb: 2.36.0
-description: Release notes for Dart and Flutter DevTools version 2.36.0.
+# description: Release notes for Dart and Flutter DevTools version 2.36.0.
+description: Dart 和 Flutter DevTools 2.36.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.36.0 release of the Dart and Flutter DevTools
@@ -11,12 +15,23 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.36.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## Performance updates
+
+## 性能更新
 
 * Added a feature for showing widget build counts.
   Enable this setting to see widget build counts for
   each Flutter frame in the "Frame Analysis" tool, or to see
   an aggregate summary of these counts in the new "Rebuild Stats" tool. -
+  [#7838](https://github.com/flutter/devtools/pull/7838), [#7847](https://github.com/flutter/devtools/pull/7847)
+
+  添加了显示 widget 构建次数的功能。
+  启用此设置可在「Frame Analysis」工具中查看每个 Flutter 帧的 widget 构建次数，
+  或在新的「Rebuild Stats」工具中查看这些次数的汇总摘要。-
   [#7838](https://github.com/flutter/devtools/pull/7838), [#7847](https://github.com/flutter/devtools/pull/7847)
 
   ![Track widget build counts setting](/assets/images/docs/tools/devtools/release-notes/images-2.36.0/track_build_counts_setting.png "Track widget build counts setting")
@@ -27,31 +42,59 @@ To learn more about DevTools, check out the
 
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Added better support for narrow viewing windows, like when
   this screen is embedded in an IDE. - [#7726](https://github.com/flutter/devtools/pull/7726)
 
+  添加了对窄视窗的更好支持，例如当此屏幕嵌入在 IDE 中时。- [#7726](https://github.com/flutter/devtools/pull/7726)
+
 ## Deep links tool updates
+
+## 深层链接工具更新
 
 * Adds an error page to explain the issue when
   the tool fails to parse the project. - [#7767](https://github.com/flutter/devtools/pull/7767)
 
+  添加了错误页面，用于在工具无法解析项目时说明问题。- [#7767](https://github.com/flutter/devtools/pull/7767)
+
 ## DevTools Extension updates
+
+## DevTools 扩展更新
 
 * Fixed an issue with detecting extensions for
   Dart or Flutter tests. - [#7717](https://github.com/flutter/devtools/pull/7717)
+
+  修复了检测 Dart 或 Flutter 测试扩展的问题。- [#7717](https://github.com/flutter/devtools/pull/7717)
 * Fixed an issue with detecting extensions for
   nested Dart or Flutter projects. - [#7742](https://github.com/flutter/devtools/pull/7742)
+
+  修复了检测嵌套 Dart 或 Flutter 项目扩展的问题。- [#7742](https://github.com/flutter/devtools/pull/7742)
 * Added an example to `package:devtools_extensions` that shows
   how to interact with the Dart Tooling Daemon from
   a DevTools extension. - [#7752](https://github.com/flutter/devtools/pull/7752)
+
+  在 `package:devtools_extensions` 中添加了示例，
+  展示如何从 DevTools 扩展与 Dart Tooling Daemon 交互。- [#7752](https://github.com/flutter/devtools/pull/7752)
 * Fixed a DevTools routing bug related to
   disabling an extension. - [#7791](https://github.com/flutter/devtools/pull/7791)
+
+  修复了与禁用扩展相关的 DevTools 路由 bug。- [#7791](https://github.com/flutter/devtools/pull/7791)
 * Fixed a bug causing a "Page Not Found" error when
   refreshing DevTools from an extension screen. - [#7822](https://github.com/flutter/devtools/pull/7822)
+
+  修复了从扩展屏幕刷新 DevTools 时出现「Page Not Found」错误的 bug。- [#7822](https://github.com/flutter/devtools/pull/7822)
 * Fixed a theming issue when extensions are
   embedded in an IDE - [#7824](https://github.com/flutter/devtools/pull/7824)
 
+  修复了扩展嵌入在 IDE 中时的主题问题 - [#7824](https://github.com/flutter/devtools/pull/7824)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.36.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.36.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.37.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.37.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.37.2 release notes
-shortTitle: 2.37.2 release notes
+# title: DevTools 2.37.2 release notes
+title: DevTools 2.37.2 发布说明
+# shortTitle: 2.37.2 release notes
+shortTitle: 2.37.2 发布说明
 breadcrumb: 2.37.2
-description: Release notes for Dart and Flutter DevTools version 2.37.2.
+# description: Release notes for Dart and Flutter DevTools version 2.37.2.
+description: Dart 和 Flutter DevTools 2.37.2 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.37.2 release of the Dart and Flutter DevTools
@@ -11,16 +15,30 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.37.2 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Improved messaging when a screen is unavailable for the
   platform of the connected app. - [#7958](https://github.com/flutter/devtools/pull/7958)
+
+  改进了当屏幕对连接应用的平台不可用时显示的消息。- [#7958](https://github.com/flutter/devtools/pull/7958)
 * Fixed a bug where an infinite spinner was shown upon
   app disconnect. - [#7992](https://github.com/flutter/devtools/pull/7992)
+
+  修复了应用断开连接时显示无限加载旋转器的 bug。- [#7992](https://github.com/flutter/devtools/pull/7992)
 * Fixed a bug where trying to reuse a disconnected DevTools instance would
   fail. - [#8009](https://github.com/flutter/devtools/pull/8009)
 
+  修复了尝试重用已断开连接的 DevTools 实例会失败的 bug。- [#8009](https://github.com/flutter/devtools/pull/8009)
+
 ## Performance updates
+
+## 性能更新
 
 * Removed the "Raster Stats" feature.
   This tool did not work for the Impeller rendering engine, and
@@ -29,22 +47,43 @@ To learn more about DevTools, check out the
   official Flutter guidance for [Performance and optimization](/perf) when
   debugging the rendering performance of their Flutter apps. - [#7981](https://github.com/flutter/devtools/pull/7981).
 
+  移除了「Raster Stats」功能。
+  此工具不适用于 Impeller 渲染引擎，
+  并且它为 SKIA 渲染引擎提供的信息通常具有误导性且无法采取行动。
+  在调试 Flutter 应用的渲染性能时，用户应遵循
+  [性能和优化](/perf) 的官方 Flutter 指南。- [#7981](https://github.com/flutter/devtools/pull/7981).
+
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Fixed an issue where socket statistics were being reported as web sockets. - [#8061](https://github.com/flutter/devtools/pull/8061)
+
+  修复了 socket 统计信息被报告为 web socket 的问题。- [#8061](https://github.com/flutter/devtools/pull/8061)
 
   ![Network profiler correctly displaying socket statistics](/assets/images/docs/tools/devtools/release-notes/images-2.37.2/socket-profiling.png "Network profiler correctly displaying socket statistics")
 
 * Added query parameters to the request details view. - [#7825](https://github.com/flutter/devtools/pull/7825)
 
+  在请求详情视图中添加了查询参数。- [#7825](https://github.com/flutter/devtools/pull/7825)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * Added buttons for all DevTools tools in the sidebar by default, even when
   there are no debug sessions available. - [#7947](https://github.com/flutter/devtools/pull/7947)
+
+  默认在侧边栏中为所有 DevTools 工具添加按钮，即使没有可用的调试会话。- [#7947](https://github.com/flutter/devtools/pull/7947)
 
   ![DevTools tools in the sidebar](/assets/images/docs/tools/devtools/release-notes/images-2.37.2/devtools_in_sidebar.png)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.37.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.37.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.38.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.38.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.38.0 release notes
-shortTitle: 2.38.0 release notes
+# title: DevTools 2.38.0 release notes
+title: DevTools 2.38.0 发布说明
+# shortTitle: 2.38.0 release notes
+shortTitle: 2.38.0 发布说明
 breadcrumb: 2.38.0
-description: Release notes for Dart and Flutter DevTools version 2.38.0.
+# description: Release notes for Dart and Flutter DevTools version 2.38.0.
+description: Dart 和 Flutter DevTools 2.38.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.38.0 release of the Dart and Flutter DevTools
@@ -11,28 +15,59 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.38.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## Performance updates
+
+## 性能更新
 
 * Renamed the "Track" builds, paints, and layouts settings to "Trace"
   builds, paints, and layouts. - [#8084](https://github.com/flutter/devtools/pull/8084)
+
+  将「Track」builds、paints 和 layouts 设置重命名为「Trace」
+  builds、paints 和 layouts。- [#8084](https://github.com/flutter/devtools/pull/8084)
 * Renamed the "Track widget build counts" setting to "Count widget builds". - [#8084](https://github.com/flutter/devtools/pull/8084)
+
+  将「Track widget build counts」设置重命名为「Count widget builds」。- [#8084](https://github.com/flutter/devtools/pull/8084)
 
 ## Debugger updates
 
+## 调试器更新
+
 * Added recommendation to debug code from an IDE, with links to IDE instructions. - [#8085](https://github.com/flutter/devtools/pull/8085)
+
+  添加了从 IDE 调试代码的建议，并附有 IDE 说明链接。- [#8085](https://github.com/flutter/devtools/pull/8085)
 
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Added support to export network requests as a HAR file (thanks to @hrajwade96!). - [#7970](https://github.com/flutter/devtools/pull/7970)
+
+  添加了将网络请求导出为 HAR 文件的支持（感谢 @hrajwade96！）。- [#7970](https://github.com/flutter/devtools/pull/7970)
 
 ## DevTools Extension updates
 
+## DevTools 扩展更新
+
 * Fixed an issue where extensions did not load with the proper theme when
   embedded in an IDE. - [#8034](https://github.com/flutter/devtools/pull/8034)
+
+  修复了扩展嵌入在 IDE 中时未以正确主题加载的问题。- [#8034](https://github.com/flutter/devtools/pull/8034)
 * Added an API for copying text to clipboard by proxy of the parent DevTools web app, which has
   workarounds for copy issues when embedded inside an IDE. - [#8130](https://github.com/flutter/devtools/pull/8130)
 
+  添加了通过父 DevTools Web 应用代理将文本复制到剪贴板的 API，
+  其中包含嵌入 IDE 内部时复制问题的解决方法。- [#8130](https://github.com/flutter/devtools/pull/8130)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.38.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.38.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.39.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.39.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.39.0 release notes
-shortTitle: 2.39.0 release notes
+# title: DevTools 2.39.0 release notes
+title: DevTools 2.39.0 发布说明
+# shortTitle: 2.39.0 release notes
+shortTitle: 2.39.0 发布说明
 breadcrumb: 2.39.0
-description: Release notes for Dart and Flutter DevTools version 2.39.0.
+# description: Release notes for Dart and Flutter DevTools version 2.39.0.
+description: Dart 和 Flutter DevTools 2.39.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.39.0 release of the Dart and Flutter DevTools
@@ -11,12 +15,24 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.39.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
 
+## 常规更新
+
 * Changed table columns to be sortable by default. - [#8175](https://github.com/flutter/devtools/pull/8175)
+
+  将表格列默认改为可排序。- [#8175](https://github.com/flutter/devtools/pull/8175)
 * Updated DevTools screen icons to match what is used in the Flutter-supported IDEs. - [#8181](https://github.com/flutter/devtools/pull/8181)
 
+  更新了 DevTools 屏幕图标，以匹配 Flutter 支持的 IDE 中使用的图标。- [#8181](https://github.com/flutter/devtools/pull/8181)
+
 ## Memory updates
+
+## 内存更新
 
 * Enabled offline analysis of memory snapshots, as well as support for viewing memory
   data when an app disconnects. For example, this may happen when an app unexpectedly
@@ -24,14 +40,32 @@ To learn more about DevTools, check out the
   [#8093](https://github.com/flutter/devtools/pull/8093),
   [#8096](https://github.com/flutter/devtools/pull/8096)
 
+  启用了内存快照的离线分析，以及应用断开连接时查看内存数据的支持。
+  例如，当应用意外崩溃或遇到内存不足问题时可能会发生这种情况。-
+  [#7843](https://github.com/flutter/devtools/pull/7843),
+  [#8093](https://github.com/flutter/devtools/pull/8093),
+  [#8096](https://github.com/flutter/devtools/pull/8096)
+
 * Fixed issue where the memory chart could cause the connected application to hit an
   out of memory exception while allocating large, short-lived objects repeatedly. - [#8209](https://github.com/flutter/devtools/pull/8209)
 
+  修复了内存图表可能导致连接的应用在反复分配大型短生命周期对象时
+  遇到内存不足异常的问题。- [#8209](https://github.com/flutter/devtools/pull/8209)
+
 ## App size tool updates
+
+## 应用大小工具更新
 
 * Added UI polish to the file import views. [#8232](https://github.com/flutter/devtools/pull/8232)
 
+  对文件导入视图进行了 UI 优化。[#8232](https://github.com/flutter/devtools/pull/8232)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.39.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.39.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.40.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.40.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.40.2 release notes
-shortTitle: 2.40.2 release notes
+# title: DevTools 2.40.2 release notes
+title: DevTools 2.40.2 发布说明
+# shortTitle: 2.40.2 release notes
+shortTitle: 2.40.2 发布说明
 breadcrumb: 2.40.2
-description: Release notes for Dart and Flutter DevTools version 2.40.2.
+# description: Release notes for Dart and Flutter DevTools version 2.40.2.
+description: Dart 和 Flutter DevTools 2.40.2 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.40.2 release of the Dart and Flutter DevTools
@@ -11,10 +15,18 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.40.2 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Add a setting that allows users to opt in to loading DevTools
   with WebAssembly. - [#8270](https://github.com/flutter/devtools/pull/8270)
+
+  添加了让用户选择使用 WebAssembly 加载 DevTools 的设置。- [#8270](https://github.com/flutter/devtools/pull/8270)
 
   ![Wasm opt-in setting](/assets/images/docs/tools/devtools/release-notes/images-2.40.2/wasm_setting.png "DevTools setting to opt into wasm.")
 
@@ -24,50 +36,91 @@ To learn more about DevTools, check out the
   Upgrade your `package:provider` dependency to
   use the extension. - [#8364](https://github.com/flutter/devtools/pull/8364)
 
+  从 DevTools 中移除了旧版 Provider 屏幕。
+  `package:provider` 工具现在作为来自 `package:provider` 的 DevTools 扩展分发。
+  升级你的 `package:provider` 依赖以使用该扩展。- [#8364](https://github.com/flutter/devtools/pull/8364)
+
 * Fixed a bug that was causing the DevTools release notes to
   always show. - [#8277](https://github.com/flutter/devtools/pull/8277)
+
+  修复了导致 DevTools 发布说明始终显示的 bug。- [#8277](https://github.com/flutter/devtools/pull/8277)
 
 * Added support for loading extensions in pub workspaces
   [8347](https://github.com/flutter/devtools/pull/8347).
 
+  添加了在 pub workspaces 中加载扩展的支持
+  [8347](https://github.com/flutter/devtools/pull/8347)。
+
 * Mapped error stack traces to use the Dart source code locations so
   that they are human-readable. - [#8385](https://github.com/flutter/devtools/pull/8385)
+
+  将错误堆栈跟踪映射为使用 Dart 源代码位置，使其易于阅读。- [#8385](https://github.com/flutter/devtools/pull/8385)
 
 * Added handling for IDE theme change events to
   update embedded DevTools UI. - [#8336](https://github.com/flutter/devtools/pull/8336)
 
+  添加了对 IDE 主题更改事件的处理，以更新嵌入的 DevTools UI。- [#8336](https://github.com/flutter/devtools/pull/8336)
+
 * Fixed a bug that was causing data filters to be cleared when clearing data
   on the Network and Logging screens. - [#8407](https://github.com/flutter/devtools/pull/8407)
+
+  修复了在 Network 和 Logging 屏幕上清除数据时导致数据过滤器被清除的 bug。- [#8407](https://github.com/flutter/devtools/pull/8407)
 
 * Fixed a bug that was causing the navigator to lose state when opening the VM
   Flags dialog. - [#8413](https://github.com/flutter/devtools/pull/8413)
 
+  修复了打开 VM Flags 对话框时导致导航器丢失状态的 bug。- [#8413](https://github.com/flutter/devtools/pull/8413)
+
 * Tables match IDE theme when embedded in an IDE. - [#8498](https://github.com/flutter/devtools/pull/8498)
+
+  嵌入在 IDE 中时，表格与 IDE 主题匹配。- [#8498](https://github.com/flutter/devtools/pull/8498)
 
 ## Inspector updates
 
+## 检查器更新
+
 - Added a setting to the Flutter Inspector controls that
   allows users to opt in to the newly redesigned Flutter Inspector. - [#8342](https://github.com/flutter/devtools/pull/8342)
+
+  在 Flutter Inspector 控件中添加了设置，
+  让用户可以选择使用全新设计的 Flutter Inspector。- [#8342](https://github.com/flutter/devtools/pull/8342)
 
   ![New inspector opt-in setting](/assets/images/docs/tools/devtools/release-notes/images-2.40.2/new_inspector.png "DevTools setting to opt into the new Flutter Inspector.")
 
 ## Performance updates
 
+## 性能更新
+
 * Fixed an issue with the "Refreshing timeline" overlay that was getting shown
   when it should not have been. - [#8318](https://github.com/flutter/devtools/pull/8318)
 
+  修复了「Refreshing timeline」叠加层在不应当显示时被显示的问题。- [#8318](https://github.com/flutter/devtools/pull/8318)
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 * Resolved an issue in `.har` export where
   response content was sometimes missing in the data. - [#8333](https://github.com/flutter/devtools/pull/8333)
 
+  解决了 `.har` 导出中响应内容有时在数据中缺失的问题。- [#8333](https://github.com/flutter/devtools/pull/8333)
+
 ## Deep links tool updates
 
+## 深层链接工具更新
+
 - Added support for validating iOS deep link settings. - [#8394](https://github.com/flutter/devtools/pull/8394)
+
+  添加了验证 iOS 深层链接设置的支持。- [#8394](https://github.com/flutter/devtools/pull/8394)
 
   ![Deep link validator for iOS](/assets/images/docs/tools/devtools/release-notes/images-2.40.2/deep_link_ios.png "DevTools Deep link validator Page")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.40.2).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.40.2)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.41.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.41.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.41.0 release notes
-shortTitle: 2.41.0 release notes
+# title: DevTools 2.41.0 release notes
+title: DevTools 2.41.0 发布说明
+# shortTitle: 2.41.0 release notes
+shortTitle: 2.41.0 发布说明
 breadcrumb: 2.41.0
-description: Release notes for Dart and Flutter DevTools version 2.41.0.
+# description: Release notes for Dart and Flutter DevTools version 2.41.0.
+description: Dart 和 Flutter DevTools 2.41.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.41.0 release of the Dart and Flutter DevTools
@@ -11,51 +15,104 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.41.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Persist filter settings across sessions. - [#8447](https://github.com/flutter/devtools/pull/8447),
   [#8456](https://github.com/flutter/devtools/pull/8456)
   [#8470](https://github.com/flutter/devtools/pull/8470)
 
+  在会话之间持久化过滤器设置。- [#8447](https://github.com/flutter/devtools/pull/8447),
+  [#8456](https://github.com/flutter/devtools/pull/8456)
+  [#8470](https://github.com/flutter/devtools/pull/8470)
+
 ## Inspector updates
+
+## 检查器更新
 
 * Added an option to the new Inspector's settings to allow
   auto-refreshing the widget tree after a hot-reload. -
   [#8483](https://github.com/flutter/devtools/pull/8483)
 
+  在新 Inspector 的设置中添加了选项，
+  让你在热重载后自动刷新 widget 树。-
+  [#8483](https://github.com/flutter/devtools/pull/8483)
+
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Added a filter text field to the top-level Network profiler controls. -
+  [#8469](https://github.com/flutter/devtools/pull/8469)
+
+  在顶层 Network profiler 控件中添加了过滤文本字段。-
   [#8469](https://github.com/flutter/devtools/pull/8469)
   ![Network filter field](/assets/images/docs/tools/devtools/release-notes/images-2.41.0/network_filter.png "Network filter field")
 
 ## Logging updates
 
+## 日志更新
+
 * Fetch log details immediately upon receiving logs so that log data is not lost
   due to lazy loading. - [#8421](https://github.com/flutter/devtools/pull/8421)
+
+  在收到日志时立即获取日志详情，以免因延迟加载而丢失日志数据。- [#8421](https://github.com/flutter/devtools/pull/8421)
 * Reduce initial page load time. - [#8500](https://github.com/flutter/devtools/pull/8500)
+
+  减少了初始页面加载时间。- [#8500](https://github.com/flutter/devtools/pull/8500)
 * Added support for displaying metadata, such as log
   severity, category, zone, and isolate -
   [#8419](https://github.com/flutter/devtools/pull/8419),
   [#8439](https://github.com/flutter/devtools/pull/8439),
   [#8441](https://github.com/flutter/devtools/pull/8441). It is now also possible to
   search and filter by these metadata values. - [#8473](https://github.com/flutter/devtools/pull/8473)
+
+  添加了显示元数据的支持，例如日志
+  严重性、类别、zone 和 isolate -
+  [#8419](https://github.com/flutter/devtools/pull/8419),
+  [#8439](https://github.com/flutter/devtools/pull/8439),
+  [#8441](https://github.com/flutter/devtools/pull/8441)。现在还可以
+  按这些元数据值进行搜索和过滤。- [#8473](https://github.com/flutter/devtools/pull/8473)
   ![Logging metadata display](/assets/images/docs/tools/devtools/release-notes/images-2.41.0/log_metadata.png "Logging metadata display")
 * Add a filter text field to the top-level Logging controls. -
+  [#8427](https://github.com/flutter/devtools/pull/8427)
+
+  在顶层 Logging 控件中添加了过滤文本字段。-
   [#8427](https://github.com/flutter/devtools/pull/8427)
   ![Logging filter](/assets/images/docs/tools/devtools/release-notes/images-2.41.0/log_filter.png "Logging filter")
 * Added support for filtering by log severity / levels. -
   [#8433](https://github.com/flutter/devtools/pull/8433)
+
+  添加了按日志严重性/级别过滤的支持。-
+  [#8433](https://github.com/flutter/devtools/pull/8433)
   ![Log level filter](/assets/images/docs/tools/devtools/release-notes/images-2.41.0/log_level_filter.png "Log level filter")
 * Added a setting to set the log retention limit. - [#8493](https://github.com/flutter/devtools/pull/8493)
+
+  添加了设置日志保留限制的配置。- [#8493](https://github.com/flutter/devtools/pull/8493)
 * Added a button to toggle the log details display between raw text and JSON. -
   [#8445](https://github.com/flutter/devtools/pull/8445)
+
+  添加了在原始文本和 JSON 之间切换日志详情显示的按钮。-
+  [#8445](https://github.com/flutter/devtools/pull/8445)
 * Fixed a bug where logs would get out of order after midnight. -
+  [#8420](https://github.com/flutter/devtools/pull/8420)
+
+  修复了午夜后日志顺序错乱的 bug。-
   [#8420](https://github.com/flutter/devtools/pull/8420)
 * Automatically scroll logs table to the bottom on the initial load. -
   [#8437](https://github.com/flutter/devtools/pull/8437)
 
+  在初始加载时自动将日志表格滚动到底部。-
+  [#8437](https://github.com/flutter/devtools/pull/8437)
+
 ## VS Code Sidebar updates
+
+## VS Code 侧边栏更新
 
 * The legacy `postMessage` version of the VS Code sidebar has been removed in
   favor of the DTD-powered version. Trying to access the legacy sidebar will
@@ -63,7 +120,18 @@ To learn more about DevTools, check out the
   Code extension was the only user of the legacy sidebar and migrated off in
   v3.96.
 
+  旧版基于 `postMessage` 的 VS Code 侧边栏已被移除，
+  改用基于 DTD 的版本。尝试访问旧版侧边栏将
+  显示一条消息，建议更新你的 Dart VS Code 扩展。
+  Dart VS Code 扩展是旧版侧边栏的唯一用户，并已在
+  v3.96 中完成迁移。
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.41.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.41.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.42.3.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.42.3.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.42.3 release notes
-shortTitle: 2.42.3 release notes
+# title: DevTools 2.42.3 release notes
+title: DevTools 2.42.3 发布说明
+# shortTitle: 2.42.3 release notes
+shortTitle: 2.42.3 发布说明
 breadcrumb: 2.42.3
-description: Release notes for Dart and Flutter DevTools version 2.42.3.
+# description: Release notes for Dart and Flutter DevTools version 2.42.3.
+description: Dart 和 Flutter DevTools 2.42.3 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.42.3 release of the Dart and Flutter DevTools
@@ -11,26 +15,56 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.42.3 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Added "View licenses" shortcut to the About dialog. - [#8610](https://github.com/flutter/devtools/pull/8610)
 
+  在「关于」对话框中添加了「View licenses」快捷方式。- [#8610](https://github.com/flutter/devtools/pull/8610)
+
 * Lower the wasm optimization level to resolve crashes on the dart2wasm build. - [#8814](https://github.com/flutter/devtools/pull/8814)
+
+  降低 wasm 优化级别以解决 dart2wasm 构建中的崩溃问题。- [#8814](https://github.com/flutter/devtools/pull/8814)
 
 ## Inspector updates
 
+## 检查器更新
+
 * Enabled the new inspector by default. This can be disabled in the inspector settings. - [#8650](https://github.com/flutter/devtools/pull/8650)
+
+  默认启用了新检查器。可以在检查器设置中禁用。- [#8650](https://github.com/flutter/devtools/pull/8650)
   ![Legacy inspector setting](/assets/images/docs/tools/devtools/release-notes/images-2.42.3/legacy_inspector_setting.png "Legacy inspector setting")
 * Fixed an issue where selecting an implementation widget on the device while implementation widgets were hidden in the new inspector showed an error. - [#8625](https://github.com/flutter/devtools/pull/8625)
+
+  修复了在新检查器中隐藏实现 widget 时，
+  在设备上选择实现 widget 会显示错误的问题。- [#8625](https://github.com/flutter/devtools/pull/8625)
 * Enabled auto-refreshes of the widget tree on hot-reloads and navigation events by default. This can be disabled in the inspector settings. - [#8646](https://github.com/flutter/devtools/pull/8646)
+
+  默认启用了在热重载和导航事件时自动刷新 widget 树。
+  可以在检查器设置中禁用。- [#8646](https://github.com/flutter/devtools/pull/8646)
   ![Auto-refresh setting](/assets/images/docs/tools/devtools/release-notes/images-2.42.3/inspector_auto_refresh_setting.png "Inspector auto-refresh setting")
 
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Fixed an issue where the HTTP requests would sometimes not be displayed properly, particularly when DevTools is communicating
   with an application over a slow network connection. - [#8860](https://github.com/flutter/devtools/pull/8860)
 
+  修复了 HTTP 请求有时无法正确显示的问题，
+  尤其是在 DevTools 通过慢速网络连接与应用程序通信时。- [#8860](https://github.com/flutter/devtools/pull/8860)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.42.3).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.42.3)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.44.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.44.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.44.0 release notes
-shortTitle: 2.44.0 release notes
+# title: DevTools 2.44.0 release notes
+title: DevTools 2.44.0 发布说明
+# shortTitle: 2.44.0 release notes
+shortTitle: 2.44.0 发布说明
 breadcrumb: 2.44.0
-description: Release notes for Dart and Flutter DevTools version 2.44.0.
+# description: Release notes for Dart and Flutter DevTools version 2.44.0.
+description: Dart 和 Flutter DevTools 2.44.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.44.0 release of the Dart and Flutter DevTools
@@ -11,7 +15,13 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.44.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Fixed various memory leaks and lifecycle issues. -
   [#8901](https://github.com/flutter/devtools/pull/8901),
@@ -28,37 +38,87 @@ To learn more about DevTools, check out the
   [#8970](https://github.com/flutter/devtools/pull/8970),
   [#8975](https://github.com/flutter/devtools/pull/8975)
 
+  修复了各种内存泄漏和生命周期问题。-
+  [#8901](https://github.com/flutter/devtools/pull/8901),
+  [#8902](https://github.com/flutter/devtools/pull/8902),
+  [#8907](https://github.com/flutter/devtools/pull/8907),
+  [#8917](https://github.com/flutter/devtools/pull/8917),
+  [#8932](https://github.com/flutter/devtools/pull/8932),
+  [#8933](https://github.com/flutter/devtools/pull/8933),
+  [#8934](https://github.com/flutter/devtools/pull/8934),
+  [#8935](https://github.com/flutter/devtools/pull/8935),
+  [#8937](https://github.com/flutter/devtools/pull/8937),
+  [#8953](https://github.com/flutter/devtools/pull/8953),
+  [#8969](https://github.com/flutter/devtools/pull/8969),
+  [#8970](https://github.com/flutter/devtools/pull/8970),
+  [#8975](https://github.com/flutter/devtools/pull/8975)
+
 ## CPU profiler updates
 
+## CPU 分析器更新
+
 * Improved the load time and memory usage of CPU profiles.
+  * [#8892](https://github.com/flutter/devtools/pull/8892)
+  * [#8878](https://github.com/flutter/devtools/pull/8878)
+  * [#8839](https://github.com/flutter/devtools/pull/8839)
+
+  改进了 CPU 配置文件的加载时间和内存使用量。
   * [#8892](https://github.com/flutter/devtools/pull/8892)
   * [#8878](https://github.com/flutter/devtools/pull/8878)
   * [#8839](https://github.com/flutter/devtools/pull/8839)
 * Fixed incorrect duration calculations when there is time during which no
   samples were taken - [#8941](https://github.com/flutter/devtools/pull/8941).
 
+  修复了在没有采集样本的时间段内持续时间计算不正确的问题 - [#8941](https://github.com/flutter/devtools/pull/8941).
+
 ## Memory updates
+
+## 内存更新
 
 * Changed the memory heap snapshot tool so that references are
   included in snapshots by default. -
   [#8899](https://github.com/flutter/devtools/pull/8899)
 
+  更改了内存堆快照工具，使引用默认包含在快照中。-
+  [#8899](https://github.com/flutter/devtools/pull/8899)
+
 ## Debugger updates
 
+## 调试器更新
+
 * Added a tooltip to describe the exception mode drop-down. -
+  [#8849](https://github.com/flutter/devtools/pull/8849)
+
+  添加了工具提示来描述异常模式下拉菜单。-
   [#8849](https://github.com/flutter/devtools/pull/8849)
 * Updated syntax highlighting with support for digit separators
   and improved comment and string interpolation handling. -
   [#8861](https://github.com/flutter/devtools/pull/8861)
+
+  更新了语法高亮，支持数字分隔符，
+  并改进了注释和字符串插值处理。-
+  [#8861](https://github.com/flutter/devtools/pull/8861)
 * Updated `string_scanner` dependency to avoid some syntax highlighting issues
   when source contains `\r\n` in certain positions on Windows. -
+  [#8904](https://github.com/flutter/devtools/pull/8904)
+
+  更新了 `string_scanner` 依赖，以避免在 Windows 上
+  源文件在某些位置包含 `\r\n` 时出现一些语法高亮问题。-
   [#8904](https://github.com/flutter/devtools/pull/8904)
 * Added soft line wrapping in the debugger console.
   [#8855](https://github.com/flutter/devtools/pull/8855).
 
+  在调试器控制台中添加了软换行。
+  [#8855](https://github.com/flutter/devtools/pull/8855).
+
 ## Network profiler updates
 
+## 网络分析器更新
+
 * Added offline support for the network screen (thanks to @hrajwade96!) -
+  [#8332](https://github.com/flutter/devtools/pull/8332)
+
+  为网络屏幕添加了离线支持（感谢 @hrajwade96！）-
   [#8332](https://github.com/flutter/devtools/pull/8332)
 
   ![Network profiler controls](/assets/images/docs/tools/devtools/release-notes/images-2.44.0/network_controls.png "Network profiler controls")
@@ -68,7 +128,15 @@ To learn more about DevTools, check out the
 * Changed the context menu style to be consistent with other screens
   [#8859](https://github.com/flutter/devtools/pull/8859).
 
+  更改了上下文菜单样式，使其与其他屏幕保持一致
+  [#8859](https://github.com/flutter/devtools/pull/8859).
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.44.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.44.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.45.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.45.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.45.0 release notes
-shortTitle: 2.45.0 release notes
+# title: DevTools 2.45.0 release notes
+title: DevTools 2.45.0 发布说明
+# shortTitle: 2.45.0 release notes
+shortTitle: 2.45.0 发布说明
 breadcrumb: 2.45.0
-description: Release notes for Dart and Flutter DevTools version 2.45.0.
+# description: Release notes for Dart and Flutter DevTools version 2.45.0.
+description: Dart 和 Flutter DevTools 2.45.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.45.0 release of the Dart and Flutter DevTools
@@ -11,7 +15,13 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.45.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 * Added a memory pressure warning that allows you to reduce the memory usage of
   DevTools in order to avoid an OOM crash. -
@@ -19,36 +29,75 @@ To learn more about DevTools, check out the
   [#8997](https://github.com/flutter/devtools/pull/8997),
   [#8998](https://github.com/flutter/devtools/pull/8998)
 
+  添加了内存压力警告，让你可以减少
+  DevTools 的内存使用量以避免 OOM 崩溃。-
+  [#8989](https://github.com/flutter/devtools/pull/8989),
+  [#8997](https://github.com/flutter/devtools/pull/8997),
+  [#8998](https://github.com/flutter/devtools/pull/8998)
+
 * Fix a bug with the review history on disconnect experience. -
+  [#8985](https://github.com/flutter/devtools/pull/8985)
+
+  修复了断开连接时查看历史记录的 bug。-
   [#8985](https://github.com/flutter/devtools/pull/8985)
 
 * Fixed bug where DevTools would automatically resume instead of
   pausing on breakpoint on connection. -
   [#8991](https://github.com/flutter/devtools/pull/8991)
 
+  修复了 DevTools 在连接时自动恢复而不是在断点处暂停的 bug。-
+  [#8991](https://github.com/flutter/devtools/pull/8991)
+
 * Prevented text inputs from stealing focus from the IDE. -
   [#9091](https://github.com/flutter/devtools/pull/9091)
 
+  防止文本输入从 IDE 窃取焦点。-
+  [#9091](https://github.com/flutter/devtools/pull/9091)
+
 ## Inspector updates
+
+## 检查器更新
 
 * Fixed bug where errors in the inspector tree (e.g. RenderFlex overflow
   errors) were not removed after a hot-reload. -
   [#9106](https://github.com/flutter/devtools/pull/9106)
 
+  修复了检查器树中的错误（例如 RenderFlex overflow
+  错误）在热重载后未被移除的 bug。-
+  [#9106](https://github.com/flutter/devtools/pull/9106)
+
 ## Debugger updates
+
+## 调试器更新
 
 * Combine the Pause and Resume buttons into a single button. -
   [#9095](https://github.com/flutter/devtools/pull/9095)
 
+  将 Pause 和 Resume 按钮合并为单个按钮。-
+  [#9095](https://github.com/flutter/devtools/pull/9095)
+
 ## Deep links tool updates
+
+## 深层链接工具更新
 
 * Fixed an issue with Windows file paths showing incorrectly in the Deep Links
   page [#9027](https://github.com/flutter/devtools/pull/9027).
 
+  修复了 Deep Links 页面中 Windows 文件路径显示不正确的问题
+  [#9027](https://github.com/flutter/devtools/pull/9027).
+
 * Fixed an issue with the Deep Links page crashing when no iOS configuration is
   present [#9027](https://github.com/flutter/devtools/pull/9027).
 
+  修复了没有 iOS 配置时 Deep Links 页面崩溃的问题
+  [#9027](https://github.com/flutter/devtools/pull/9027).
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.45.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.45.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.46.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.46.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.46.0 release notes
-shortTitle: 2.46.0 release notes
+# title: DevTools 2.46.0 release notes
+title: DevTools 2.46.0 发布说明
+# shortTitle: 2.46.0 release notes
+shortTitle: 2.46.0 发布说明
 breadcrumb: 2.46.0
-description: Release notes for Dart and Flutter DevTools version 2.46.0.
+# description: Release notes for Dart and Flutter DevTools version 2.46.0.
+description: Dart 和 Flutter DevTools 2.46.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.46.0 release of the Dart and Flutter DevTools
@@ -11,19 +15,42 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.46.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Fixed a bug which caused web apps to remain paused after triggering a hot-restart from
   DevTools. - [#9125](https://github.com/flutter/devtools/pull/9125)
+
+  修复了一个 bug，该 bug 导致 Web 应用在从
+  DevTools 触发热重启后仍保持暂停状态。- [#9125](https://github.com/flutter/devtools/pull/9125)
 - Landed a change to dismiss stale banner messages when the connected app state changes. - [#9148](https://github.com/flutter/devtools/pull/9148)
+
+  落地了一项更改，在连接的应用状态更改时关闭过时的横幅消息。- [#9148](https://github.com/flutter/devtools/pull/9148)
 - Fixed a focus traversal issue with search fields. [#9166](https://github.com/flutter/devtools/pull/9166)
 
+  修复了搜索字段的焦点遍历问题。[#9166](https://github.com/flutter/devtools/pull/9166)
+
 ## Performance updates
+
+## 性能更新
 
 - Fixed a bug where the Performance page would hang when connected to a paused
   Flutter app. - [#9162](https://github.com/flutter/devtools/pull/9162)
 
+  修复了连接到已暂停的
+  Flutter 应用时性能页面会挂起的 bug。- [#9162](https://github.com/flutter/devtools/pull/9162)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.46.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.46.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.47.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.47.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.47.0 release notes
-shortTitle: 2.47.0 release notes
+# title: DevTools 2.47.0 release notes
+title: DevTools 2.47.0 发布说明
+# shortTitle: 2.47.0 release notes
+shortTitle: 2.47.0 发布说明
 breadcrumb: 2.47.0
-description: Release notes for Dart and Flutter DevTools version 2.47.0.
+# description: Release notes for Dart and Flutter DevTools version 2.47.0.
+description: Dart 和 Flutter DevTools 2.47.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.47.0 release of the Dart and Flutter DevTools
@@ -11,12 +15,26 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.47.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Fixed an issue where copying all logs in the console would show `null` for
   any inspected widgets. - [#9204](https://github.com/flutter/devtools/pull/9204)
 
+  修复了在控制台中复制所有日志时，
+  任何已检查的 widget 都会显示 `null` 的问题。- [#9204](https://github.com/flutter/devtools/pull/9204)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.47.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.47.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.48.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.48.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.48.0 release notes
-shortTitle: 2.48.0 release notes
+# title: DevTools 2.48.0 release notes
+title: DevTools 2.48.0 发布说明
+# shortTitle: 2.48.0 release notes
+shortTitle: 2.48.0 发布说明
 breadcrumb: 2.48.0
-description: Release notes for Dart and Flutter DevTools version 2.48.0.
+# description: Release notes for Dart and Flutter DevTools version 2.48.0.
+description: Dart 和 Flutter DevTools 2.48.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.48.0 release of the Dart and Flutter DevTools
@@ -11,17 +15,33 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.48.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 * Fixed network logging after a hot restart. -
   [#9271](https://github.com/flutter/devtools/pull/9271).
 
+  修复了热重启后的网络日志记录问题。-
+  [#9271](https://github.com/flutter/devtools/pull/9271).
+
 ## Logging updates
+
+## 日志更新
 
 * Started displaying events related to timers in the Logging View. -
   [#9238](https://github.com/flutter/devtools/pull/9238).
 
+  开始在 Logging View 中显示与 timer 相关的事件。-
+  [#9238](https://github.com/flutter/devtools/pull/9238).
+
 ## Advanced developer mode updates
+
+## 高级开发者模式更新
 
 * Added a Queued Microtasks tab to the VM Tools screen, which allows a user to
   see details about the microtasks scheduled in an isolate's microtask queue.
@@ -29,7 +49,18 @@ To learn more about DevTools, check out the
   Dart app started with `--profile-microtasks`. -
   [#9239](https://github.com/flutter/devtools/pull/9239).
 
+  在 VM Tools 屏幕中添加了 Queued Microtasks 标签页，让你可以
+  查看在 isolate 的微任务队列中调度的微任务详情。
+  此标签页目前仅在 DevTools 连接到使用 `--profile-microtasks` 启动的
+  Flutter 或 Dart 应用时出现。-
+  [#9239](https://github.com/flutter/devtools/pull/9239).
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.48.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.48.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.49.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.49.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.49.0 release notes
-shortTitle: 2.49.0 release notes
+# title: DevTools 2.49.0 release notes
+title: DevTools 2.49.0 发布说明
+# shortTitle: 2.49.0 release notes
+shortTitle: 2.49.0 发布说明
 breadcrumb: 2.49.0
-description: Release notes for Dart and Flutter DevTools version 2.49.0.
+# description: Release notes for Dart and Flutter DevTools version 2.49.0.
+description: Dart 和 Flutter DevTools 2.49.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.49.0 release of the Dart and Flutter DevTools
@@ -11,13 +15,28 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.49.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Fixed a bug preventing the buttons at the top of an embedded DevTools screen
   from being clicked under certain circumstances. -
   [#9327](https://github.com/flutter/devtools/pull/9327)
 
+  修复了一个 bug，该 bug 在某些情况下阻止点击
+  嵌入 DevTools 屏幕顶部的按钮。-
+  [#9327](https://github.com/flutter/devtools/pull/9327)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.49.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.49.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.50.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.50.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.50.0 release notes
-shortTitle: 2.50.0 release notes
+# title: DevTools 2.50.0 release notes
+title: DevTools 2.50.0 发布说明
+# shortTitle: 2.50.0 release notes
+shortTitle: 2.50.0 发布说明
 breadcrumb: 2.50.0
-description: Release notes for Dart and Flutter DevTools version 2.50.0.
+# description: Release notes for Dart and Flutter DevTools version 2.50.0.
+description: Dart 和 Flutter DevTools 2.50.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.50.0 release of the Dart and Flutter DevTools
@@ -11,13 +15,28 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.50.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## CPU profiler updates
+
+## CPU 分析器更新
 
 - Deleted the "Profile app start up" button in favor of the new Dart/Flutter
   `--profile-startup` CLI flags. -
   [#9358](https://github.com/flutter/devtools/pull/9358)
 
+  删除了「Profile app start up」按钮，
+  改用新的 Dart/Flutter `--profile-startup` CLI 标志。-
+  [#9358](https://github.com/flutter/devtools/pull/9358)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.50.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.50.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.51.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.51.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.51.0 release notes
-shortTitle: 2.51.0 release notes
+# title: DevTools 2.51.0 release notes
+title: DevTools 2.51.0 发布说明
+# shortTitle: 2.51.0 release notes
+shortTitle: 2.51.0 发布说明
 breadcrumb: 2.51.0
-description: Release notes for Dart and Flutter DevTools version 2.51.0.
+# description: Release notes for Dart and Flutter DevTools version 2.51.0.
+description: Dart 和 Flutter DevTools 2.51.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.51.0 release of the Dart and Flutter DevTools
@@ -11,19 +15,40 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.51.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Flutter beta channel users were opted into the DevTools-on-Wasm experiment.
   All other users can still enable the Wasm-compiled DevTools from the settings
   dialog. - [#9455](https://github.com/flutter/devtools/pull/9455)
 
+  Flutter beta 渠道用户已默认加入 DevTools-on-Wasm 实验。
+  所有其他用户仍可以从设置
+  对话框中启用 Wasm 编译的 DevTools。- [#9455](https://github.com/flutter/devtools/pull/9455)
+
 ## Inspector updates
+
+## 检查器更新
 
 - Fixed an issue where selecting a widget with the Inspector would open the
   widget definition file instead of the user's project file. -
   [#176530](https://github.com/flutter/flutter/pull/176530)
 
+  修复了使用 Inspector 选择 widget 时会打开
+  widget 定义文件而不是用户项目文件的问题。-
+  [#176530](https://github.com/flutter/flutter/pull/176530)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.51.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.51.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.51.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.51.1.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.51.1 release notes
-shortTitle: 2.51.1 release notes
+# title: DevTools 2.51.1 release notes
+title: DevTools 2.51.1 发布说明
+# shortTitle: 2.51.1 release notes
+shortTitle: 2.51.1 发布说明
 breadcrumb: 2.51.1
 showToc: false
+ai-translated: true
 ---
 
 The 2.51.1 release of the Dart and Flutter DevTools
@@ -10,38 +13,82 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.51.1 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Flutter beta channel users were opted into the DevTools-on-Wasm experiment.
   All other users can still enable the Wasm-compiled DevTools from the settings
   dialog. - [#9455](https://github.com/flutter/devtools/pull/9455)
+
+  Flutter beta 渠道用户已默认加入 DevTools-on-Wasm 实验。
+  所有其他用户仍可以从设置
+  对话框中启用 Wasm 编译的 DevTools。- [#9455](https://github.com/flutter/devtools/pull/9455)
 - Added a horizontal scrollbar to data tables to help with navigation. -
+  [#9482](https://github.com/flutter/devtools/pull/9482)
+
+  在数据表格中添加了水平滚动条以帮助导航。-
   [#9482](https://github.com/flutter/devtools/pull/9482)
 - Made it possible to resize data table columns by dragging the header separators. -
   [#9485](https://github.com/flutter/devtools/pull/9485)
 
+  可以通过拖动标题分隔符来调整数据表格列的大小。-
+  [#9485](https://github.com/flutter/devtools/pull/9485)
+
 ## Inspector updates
+
+## 检查器更新
 
 - Fixed an issue where selecting a widget with the Inspector would open the
   widget definition file instead of the user's project file. -
   [#176530](https://github.com/flutter/flutter/pull/176530)
 
+  修复了使用 Inspector 选择 widget 时会打开
+  widget 定义文件而不是用户项目文件的问题。-
+  [#176530](https://github.com/flutter/flutter/pull/176530)
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 - Fixed layout of the "error count" badge in the tab name. -
   [#9470](https://github.com/flutter/devtools/pull/9470)
+
+  修复了标签页名称中「error count」徽章的布局。-
+  [#9470](https://github.com/flutter/devtools/pull/9470)
 - Fixed display of "Response Headers" and "Request Headers" when there are no
   headers. - [#9492](https://github.com/flutter/devtools/pull/9492)
+
+  修复了没有
+  标头时「Response Headers」和「Request Headers」的显示。- [#9492](https://github.com/flutter/devtools/pull/9492)
 - Added a banner to clearly indicate when DevTools is not logging network
   requests. - [#9495](https://github.com/flutter/devtools/pull/9495)
 
+  添加了横幅，用于清楚地指示 DevTools 未记录网络
+  请求时的情况。- [#9495](https://github.com/flutter/devtools/pull/9495)
+
 ## VS Code updates
+
+## VS Code 更新
 
 - Fixed issue preventing shortcuts like `Cmd`+`C` and `Cmd`+`V` from working when DevTools was
   embedded inside VS Code on macOS. -
   [#9472](https://github.com/flutter/devtools/pull/9472)
 
+  修复了在 macOS 上将 DevTools 嵌入
+  VS Code 内部时 `Cmd`+`C` 和 `Cmd`+`V` 等快捷键无法使用的问题。-
+  [#9472](https://github.com/flutter/devtools/pull/9472)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.51.1).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.51.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.52.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.52.0.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.52.0 release notes
-shortTitle: 2.52.0 release notes
+# title: DevTools 2.52.0 release notes
+title: DevTools 2.52.0 发布说明
+# shortTitle: 2.52.0 release notes
+shortTitle: 2.52.0 发布说明
 breadcrumb: 2.52.0
 showToc: false
+ai-translated: true
 ---
 
 The 2.52.0 release of the Dart and Flutter DevTools
@@ -10,29 +13,63 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.52.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
 
+## 常规更新
+
 - Added a horizontal scrollbar to data tables to help with navigation. -
+  [#9482](https://github.com/flutter/devtools/pull/9482)
+
+  在数据表格中添加了水平滚动条以帮助导航。-
   [#9482](https://github.com/flutter/devtools/pull/9482)
 - Made it possible to resize data table columns by dragging the header separators. -
   [#9485](https://github.com/flutter/devtools/pull/9485)
 
+  可以通过拖动标题分隔符来调整数据表格列的大小。-
+  [#9485](https://github.com/flutter/devtools/pull/9485)
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 - Fixed layout of the "error count" badge in the tab name. -
   [#9470](https://github.com/flutter/devtools/pull/9470)
+
+  修复了标签页名称中「error count」徽章的布局。-
+  [#9470](https://github.com/flutter/devtools/pull/9470)
 - Fixed display of "Response Headers" and "Request Headers" when there are no
   headers. - [#9492](https://github.com/flutter/devtools/pull/9492)
+
+  修复了没有
+  标头时「Response Headers」和「Request Headers」的显示。- [#9492](https://github.com/flutter/devtools/pull/9492)
 - Added a banner to clearly indicate when DevTools is not logging network
   requests. - [#9495](https://github.com/flutter/devtools/pull/9495)
 
+  添加了横幅，用于清楚地指示 DevTools 未记录网络
+  请求时的情况。- [#9495](https://github.com/flutter/devtools/pull/9495)
+
 ## VS Code updates
+
+## VS Code 更新
 
 - Fixed issue preventing shortcuts like `Cmd`+`C` and `Cmd`+`V` from working when DevTools was
   embedded inside VS Code on macOS. -
   [#9472](https://github.com/flutter/devtools/pull/9472)
 
+  修复了在 macOS 上将 DevTools 嵌入
+  VS Code 内部时 `Cmd`+`C` 和 `Cmd`+`V` 等快捷键无法使用的问题。-
+  [#9472](https://github.com/flutter/devtools/pull/9472)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.52.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.52.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.53.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.53.0.md
@@ -1,34 +1,64 @@
 ---
-title: DevTools 2.53.0 release notes
-shortTitle: 2.53.0 release notes
+# title: DevTools 2.53.0 release notes
+title: DevTools 2.53.0 发布说明
+# shortTitle: 2.53.0 release notes
+shortTitle: 2.53.0 发布说明
 breadcrumb: 2.53.0
 showToc: false
+ai-translated: true
 ---
 
 # DevTools 2.53.0 release notes
+
+# DevTools 2.53.0 发布说明
 
 The 2.53.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.53.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Switched default compiler for DevTools to `dart2wasm`. -
   [#9530](https://github.com/flutter/devtools/pull/9530)
 
+  将 DevTools 的默认编译器切换为 `dart2wasm`。-
+  [#9530](https://github.com/flutter/devtools/pull/9530)
+
 ## Performance updates
+
+## 性能更新
 
 - Increased profile data limit from 64MB to 2GB, fixing issue where panel
   wouldn't load for large profiles. -
   [#9540](https://github.com/flutter/devtools/pull/9540)
 
+  将配置文件数据限制从 64MB 增加到 2GB，修复了大型配置文件
+  无法加载面板的问题。-
+  [#9540](https://github.com/flutter/devtools/pull/9540)
+
 ## Advanced developer mode updates
+
+## 高级开发者模式更新
 
 - Fixed issue preventing CPU profiles from loading when "advanced developer
   mode" was enabled. - [#9528](https://github.com/flutter/devtools/pull/9528)
 
+  修复了启用「advanced developer
+  mode」时无法加载 CPU 配置文件的问题。- [#9528](https://github.com/flutter/devtools/pull/9528)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.53.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.53.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.54.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.54.0.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.54.0 release notes
-shortTitle: 2.54.0 release notes
+# title: DevTools 2.54.0 release notes
+title: DevTools 2.54.0 发布说明
+# shortTitle: 2.54.0 release notes
+shortTitle: 2.54.0 发布说明
 breadcrumb: 2.54.0
 showToc: false
+ai-translated: true
 ---
 
 The 2.54.0 release of the Dart and Flutter DevTools
@@ -10,32 +13,67 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools/overview).
 
+Dart 和 Flutter DevTools 的 2.54.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools/overview)。
+
 ## General updates
+
+## 常规更新
 
 - Dropped connections to DTD will now automatically be retried to improve the
   experience when your machine is resumed from sleep. -
   [#9587](https://github.com/flutter/devtools/pull/9587)
 
+  断开的 DTD 连接现在会自动重试，以改善
+  计算机从睡眠状态恢复时的体验。-
+  [#9587](https://github.com/flutter/devtools/pull/9587)
+
 ## Inspector updates
+
+## 检查器更新
 
 - Added a warning banner that the legacy inspector
   will be removed in a future release. -
   [#9572](https://github.com/flutter/devtools/pull/9572)
 
+  添加了警告横幅，提示旧版检查器
+  将在未来版本中移除。-
+  [#9572](https://github.com/flutter/devtools/pull/9572)
+
 ## Memory updates
+
+## 内存更新
 
 - Fixed an error preventing users from changing the zoom duration. -
   [#9573](https://github.com/flutter/devtools/pull/9573)
 
+  修复了阻止用户更改缩放持续时间的错误。-
+  [#9573](https://github.com/flutter/devtools/pull/9573)
+
 ## Deep links tool updates
+
+## 深层链接工具更新
 
 - Added a more informative dialog if the Deep Links tool is
   unable to find build options for the iOS or Android app. -
   [#9571](https://github.com/flutter/devtools/pull/9571)
+
+  如果 Deep Links 工具
+  无法找到 iOS 或 Android 应用的构建选项，则添加了更具信息量的对话框。-
+  [#9571](https://github.com/flutter/devtools/pull/9571)
 - Fixed null error when parsing universal link settings. -
+  [#9581](https://github.com/flutter/devtools/pull/9581)
+
+  修复了解析通用链接设置时的 null 错误。-
   [#9581](https://github.com/flutter/devtools/pull/9581)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.54.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.54.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.55.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.55.0.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.55.0 release notes
-shortTitle: 2.55.0 release notes
+# title: DevTools 2.55.0 release notes
+title: DevTools 2.55.0 发布说明
+# shortTitle: 2.55.0 release notes
+shortTitle: 2.55.0 发布说明
 breadcrumb: 2.55.0
 showToc: false
+ai-translated: true
 ---
 
 The 2.55.0 release of the Dart and Flutter DevTools
@@ -10,7 +13,16 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.55.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.55.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.55.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.57.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.57.0.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.57.0 release notes
-shortTitle: 2.57.0 release notes
+# title: DevTools 2.57.0 release notes
+title: DevTools 2.57.0 发布说明
+# shortTitle: 2.57.0 release notes
+shortTitle: 2.57.0 发布说明
 breadcrumb: 2.57.0
 showToc: false
+ai-translated: true
 ---
 
 The 2.57.0 release of the Dart and Flutter DevTools
@@ -10,21 +13,42 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.57.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 - Added a filter setting to hide HTTP-profiler socket data. [#9698](https://github.com/flutter/devtools/pull/9698)
 
+  添加了隐藏 HTTP-profiler socket 数据的过滤设置。[#9698](https://github.com/flutter/devtools/pull/9698)
+
 ## Logging updates
 
+## 日志更新
+
 - Added support for searching within the log details view (raw text mode). [#9712](https://github.com/flutter/devtools/pull/9712)
+
+  添加了在日志详情视图（原始文本模式）中搜索的支持。[#9712](https://github.com/flutter/devtools/pull/9712)
 
   ![Search in log details](/assets/images/docs/tools/devtools/release-notes/images-2.57.0/log_details_search.png "Searching within the log details view")
 
 ## App size tool updates
 
+## 应用大小工具更新
+
 - Added documentation links and improved handling for null files. [#9689](https://github.com/flutter/devtools/pull/9689)
+
+  添加了文档链接并改进了对 null 文件的处理。[#9689](https://github.com/flutter/devtools/pull/9689)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.57.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.57.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.58.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.58.0.md
@@ -1,8 +1,11 @@
 ---
-title: DevTools 2.58.0 release notes
-shortTitle: 2.58.0 release notes
+# title: DevTools 2.58.0 release notes
+title: DevTools 2.58.0 发布说明
+# shortTitle: 2.58.0 release notes
+shortTitle: 2.58.0 发布说明
 breadcrumb: 2.58.0
 showToc: false
+ai-translated: true
 ---
 
 The 2.58.0 release of the Dart and Flutter DevTools
@@ -10,42 +13,95 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.58.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## Inspector updates
+
+## 检查器更新
 
 - Deleted the option to use the legacy inspector.
   [#9782](https://github.com/flutter/devtools/pull/9782)
+
+  删除了使用旧版检查器的选项。
+  [#9782](https://github.com/flutter/devtools/pull/9782)
 - Fixed an issue where navigating the Inspector widget tree with the keyboard arrow keys did not update the selected widget in the connected Flutter app. [#9810](https://github.com/flutter/devtools/pull/9810)
+
+  修复了使用键盘方向键导航 Inspector widget 树时
+  未更新已连接 Flutter 应用中选定 widget 的问题。[#9810](https://github.com/flutter/devtools/pull/9810)
 - Fixed an issue where clicking a widget row after collapsing a subtree with the left arrow key unexpectedly re-expanded the subtree. [#9810](https://github.com/flutter/devtools/pull/9810)
+
+  修复了使用左方向键折叠子树后点击 widget 行
+  会意外重新展开子树的问题。[#9810](https://github.com/flutter/devtools/pull/9810)
 - Fixed an issue where collapsing the Inspector widget tree to a single row with the left arrow key caused a loading spinner to appear instead of showing the root node. [#9810](https://github.com/flutter/devtools/pull/9810)
 
+  修复了使用左方向键将 Inspector widget 树折叠为单行时
+  出现加载旋转器而不是显示根节点的问题。[#9810](https://github.com/flutter/devtools/pull/9810)
+
 ## Performance updates
+
+## 性能更新
 
 - Fixed an issue where 'More Debug Options' showed options as unselected in
 profile mode even when selected. [#9813](https://github.com/flutter/devtools/issues/9813)
 
+  修复了在 profile 模式下即使已选中，
+  「More Debug Options」仍显示选项为未选中的问题。[#9813](https://github.com/flutter/devtools/issues/9813)
+
 ## Debugger updates
+
+## 调试器更新
 
 - Fixed an issue where long string values in the console/variables view would overflow and overlap with other elements. [#7112](https://github.com/flutter/devtools/issues/7112)
 
+  修复了控制台/变量视图中长字符串值会溢出并与其他元素重叠的问题。[#7112](https://github.com/flutter/devtools/issues/7112)
+
 ## Network profiler updates
+
+## 网络分析器更新
 
 - Added response size column to the Network tab and displayed response size in the request inspector overview.  
   [#9744](https://github.com/flutter/devtools/pull/9744)
 
+  在 Network 标签页中添加了响应大小列，并在请求检查器概览中显示响应大小。
+  [#9744](https://github.com/flutter/devtools/pull/9744)
+
 - Improved HTTP request status classification in the Network tab to better distinguish cancelled, completed, and in-flight requests (for example, avoiding some cases where cancelled requests appeared as pending). [#9683](https://github.com/flutter/devtools/pull/9683)
 
+  改进了 Network 标签页中的 HTTP 请求状态分类，
+  以更好地区分已取消、已完成和进行中的请求
+  （例如，避免某些已取消请求显示为待处理的情况）。[#9683](https://github.com/flutter/devtools/pull/9683)
+
 - Added a filter setting to hide HTTP-profiler socket data.  
+  [#9698](https://github.com/flutter/devtools/pull/9698)
+
+  添加了隐藏 HTTP-profiler socket 数据的过滤设置。
   [#9698](https://github.com/flutter/devtools/pull/9698)
   
 ## Logging updates
 
+## 日志更新
+
 - Fixed an issue where log messages containing newline characters were incorrectly split into multiple separate entries in the Logging screen. [#9757](https://github.com/flutter/devtools/pull/9757)
+
+  修复了包含换行符的日志消息在 Logging 屏幕中
+  被错误拆分为多个独立条目的问题。[#9757](https://github.com/flutter/devtools/pull/9757)
 
 ## Deep links tool updates
 
+## 深层链接工具更新
+
 - Pluralized "domain" and "path" in the validation summary notification titles when multiple errors are present. [#9790](https://github.com/flutter/devtools/pull/9790)
+
+  当存在多个错误时，在验证摘要通知标题中将「domain」和「path」复数化。[#9790](https://github.com/flutter/devtools/pull/9790)
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes in this release, check out the
 [DevTools git log](https://github.com/flutter/devtools/tree/v2.58.0).
+
+要查看此版本的完整更改列表，请查看
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.58.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.7.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.7.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.7.0 release notes
-shortTitle: 2.7.0 release notes
+# title: DevTools 2.7.0 release notes
+title: DevTools 2.7.0 发布说明
+# shortTitle: 2.7.0 release notes
+shortTitle: 2.7.0 发布说明
 breadcrumb: 2.7.0
-description: Release notes for Dart and Flutter DevTools version 2.7.0.
+# description: Release notes for Dart and Flutter DevTools version 2.7.0.
+description: Dart 和 Flutter DevTools 2.7.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.7.0 release of the Dart and Flutter DevTools
@@ -11,17 +15,38 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.7.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](/tools/devtools)。
+
 ## General updates
 
+## 常规更新
+
 * Improvements for initial page load time -
+  [#3309](https://github.com/flutter/devtools/pull/3309)
+
+  改进了初始页面加载时间 -
   [#3309](https://github.com/flutter/devtools/pull/3309)
 * Fix a couple scrollbar-related issues -
   [#3393](https://github.com/flutter/devtools/pull/3393),
   [#3401](https://github.com/flutter/devtools/pull/3401)
 
+  修复了几个与滚动条相关的问题 -
+  [#3393](https://github.com/flutter/devtools/pull/3393),
+  [#3401](https://github.com/flutter/devtools/pull/3401)
+
 ## Debugger updates
 
+## 调试器更新
+
 * Add an open file dialog (ctrl / cmd + p) -
+  [#3342](https://github.com/flutter/devtools/pull/3342),
+  [#3354](https://github.com/flutter/devtools/pull/3354),
+  [#3371](https://github.com/flutter/devtools/pull/3371),
+  [#3384](https://github.com/flutter/devtools/pull/3384)
+
+  添加了打开文件对话框（ctrl / cmd + p）-
   [#3342](https://github.com/flutter/devtools/pull/3342),
   [#3354](https://github.com/flutter/devtools/pull/3354),
   [#3371](https://github.com/flutter/devtools/pull/3371),
@@ -32,13 +57,23 @@ To learn more about DevTools, check out the
 * Add a copy button to the call stack view -
   [#3334](https://github.com/flutter/devtools/pull/3334)
 
+  在调用堆栈视图中添加了复制按钮 -
+  [#3334](https://github.com/flutter/devtools/pull/3334)
+
   ![Call stack view](/assets/images/docs/tools/devtools/release-notes/images-2.7.0/image2.png "Call stack view")
 
 ## CPU profiler updates
 
+## CPU 分析器更新
+
 * Added functionality to load an app startup profile for Flutter apps.
   This profile will contain CPU samples from the initialization
   of the Dart VM up until the first Flutter frame has been rendered -
+  [#3357](https://github.com/flutter/devtools/pull/3357)
+
+  添加了为 Flutter 应用加载应用启动配置文件的功能。
+  此配置文件将包含从 Dart VM 初始化
+  到渲染第一个 Flutter 帧之间的 CPU 样本 -
   [#3357](https://github.com/flutter/devtools/pull/3357)
 
   ![Profile button](/assets/images/docs/tools/devtools/release-notes/images-2.7.0/image3.png "Profile button")
@@ -49,6 +84,12 @@ To learn more about DevTools, check out the
   by selecting this user tag filter, when present,
   in the list of available user tags.
 
+  加载应用启动配置文件后，
+  你会看到为配置文件选中了「AppStartUp」用户标签。
+  你也可以在可用用户标签列表中
+  选择此用户标签过滤器（如果存在）来
+  加载应用启动配置文件。
+
   ![User tag example](/assets/images/docs/tools/devtools/release-notes/images-2.7.0/image4.png "User tag example")
 
 * Added multi-isolate support.
@@ -56,15 +97,28 @@ To learn more about DevTools, check out the
   from the isolate selector at the bottom of the page -
   [#3362](https://github.com/flutter/devtools/pull/3362)
 
+  添加了多 isolate 支持。
+  从页面底部的 isolate 选择器中选择
+  你要分析的 isolate -
+  [#3362](https://github.com/flutter/devtools/pull/3362)
+
   ![isolate selector](/assets/images/docs/tools/devtools/release-notes/images-2.7.0/image5.png "isolate selector")
 
 * Add class names to CPU stack frames in the profiler -
+  [#3385](https://github.com/flutter/devtools/pull/3385)
+
+  在 profiler 中为 CPU 堆栈帧添加类名 -
   [#3385](https://github.com/flutter/devtools/pull/3385)
 
   ![Class names](/assets/images/docs/tools/devtools/release-notes/images-2.7.0/image6.png "Class names")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.6.0...v2.7.0).
+
+要查看自上一版本以来的完整更改列表，请查看
+[GitHub 上的差异](https://github.com/flutter/devtools/compare/v2.6.0...v2.7.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.8.0.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.8.0.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.8.0 release notes
-shortTitle: 2.8.0 release notes
+# title: DevTools 2.8.0 release notes
+title: DevTools 2.8.0 发布说明
+# shortTitle: 2.8.0 release notes
+shortTitle: 2.8.0 发布说明
 breadcrumb: 2.8.0
-description: Release notes for Dart and Flutter DevTools version 2.8.0.
+# description: Release notes for Dart and Flutter DevTools version 2.8.0.
+description: Dart 和 Flutter DevTools 2.8.0 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.8.0 release of the Dart and Flutter DevTools
@@ -11,12 +15,25 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.8.0 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Improvements for initial page load time -
   [#3325](https://github.com/flutter/devtools/pull/3325)
+
+  改进了初始页面加载时间 -
+  [#3325](https://github.com/flutter/devtools/pull/3325)
 * Performance improvements for connecting DevTools to a device,
   particularly impactful for low-memory devices -
+  [#3468](https://github.com/flutter/devtools/pull/3468)
+
+  改进了将 DevTools 连接到设备的性能，
+  对低内存设备尤其有效 -
   [#3468](https://github.com/flutter/devtools/pull/3468)
 * For users on Flutter 2.8.0 or greater (or Dart 2.15.0 or greater),
   DevTools should now be launched via the `dart devtools` command
@@ -26,16 +43,31 @@ To learn more about DevTools, check out the
   If you see this warning,
   be sure to open DevTools via `dart devtools` instead of from pub:
 
+  对于使用 Flutter 2.8.0 或更高版本（或 Dart 2.15.0 或更高版本）的用户，
+  现在应通过 `dart devtools` 命令启动 DevTools，
+  而不是运行 `pub global activate devtools`。
+  DevTools 2.8.0 将是通过 pub 发布的最后一个 DevTools 版本，
+  未来所有版本的 DevTools 都将作为 Dart SDK 的一部分发布。
+  如果你看到此警告，
+  请务必通过 `dart devtools` 而不是从 pub 打开 DevTools：
+
   ![dart devtools warning dialog](/assets/images/docs/tools/devtools/release-notes/images-2.8.0/image1.png "dart devtools warning dialog")
 
 ## Performance updates
 
+## 性能更新
+
 * Added a new "Enhance Tracing" feature to help users diagnose UI jank
   stemming from expensive Build, Layout, and Paint operations.
+
+  添加了新的「Enhance Tracing」功能，帮助用户诊断
+  源于昂贵的 Build、Layout 和 Paint 操作的 UI 卡顿。
 
   ![Enhance tracing](/assets/images/docs/tools/devtools/release-notes/images-2.8.0/image2.png "Enhance tracing")
 
   The expected workflow is as such:
+
+  预期工作流程如下：
 
   1. User is investigating UI jank in the performance page
   2. User notices a long Build, Layout, and/or Paint event
@@ -45,14 +77,27 @@ To learn more about DevTools, check out the
      additional child events for widgets built, render objects laid out,
      and/or render objects painted
 
+  1. 用户在性能页面调查 UI 卡顿
+  2. 用户注意到较长的 Build、Layout 和/或 Paint 事件
+  3. 用户在「Enhance Tracing」功能中打开相应的跟踪切换开关
+  4. 用户在其应用中重现 UI 卡顿
+  5. 用户查看新的一组 Timeline 事件，现在应该包含
+     已构建 widget、已布局渲染对象
+     和/或已绘制渲染对象的额外子事件
+
   ![Timeline events](/assets/images/docs/tools/devtools/release-notes/images-2.8.0/image3.png "Timeline events")
 
 * Added new "More debugging options" feature to allow for disabling
   rendering layers for Clip, Opacity, and Physical Shapes.
 
+  添加了新的「More debugging options」功能，允许禁用
+  Clip、Opacity 和 Physical Shapes 的渲染层。
+
   ![More debugging options](/assets/images/docs/tools/devtools/release-notes/images-2.8.0/image4.png "More debugging options")
 
   The expected workflow is as such:
+
+  预期工作流程如下：
 
   1. User is investigating UI jank in the performance page
   2. User notices a lot of janky frames and suspects it could be due to
@@ -67,11 +112,30 @@ To learn more about DevTools, check out the
      the user now knows that the performance problem
      is not due to these UI effects.
 
+  1. 用户在性能页面调查 UI 卡顿
+  2. 用户注意到大量卡顿帧，怀疑可能是由于
+     过度使用裁剪、透明度或物理形状。
+  3. 用户在「More debugging options」功能中
+     关闭相应的渲染层切换开关
+  4. 用户在其应用中重现 UI 卡顿
+  5. 如果关闭渲染层后 UI 卡顿减少，
+     用户应尝试优化应用以
+     减少裁剪/透明度/物理形状效果的使用。
+     如果 UI 卡顿没有减少，
+     用户现在知道性能问题
+     不是由这些 UI 效果引起的。
+
 ## Debugger updates
+
+## 调试器更新
 
 * Replaced the "Libraries" pane with a "File Explorer" pane -
   [#3448](https://github.com/flutter/devtools/pull/3448).
   The "File Explorer" pane has two components:
+
+  将「Libraries」面板替换为「File Explorer」面板 -
+  [#3448](https://github.com/flutter/devtools/pull/3448)。
+  「File Explorer」面板有两个组件：
 
   1. A tree view of the libraries present in your application.
      You can use the File Explorer to find and open a library,
@@ -83,17 +147,41 @@ To learn more about DevTools, check out the
      the source view will jump to the respective line of code
      for the selected item.
 
+  1. 应用程序中现有库的树形视图。
+     你可以使用 File Explorer 查找并打开库，
+     或者你可以使用现有的 <kbd>Ctrl</kbd> / <kbd>Cmd</kbd> +
+     <kbd>P</kbd> 键盘快捷键搜索文件。
+  1. 新的「Outline」视图，显示所选库的结构。
+     此视图将显示类、成员、方法等，
+     当选中某项时，
+     源代码视图将跳转到
+     所选项对应的代码行。
+
   ![Outline view selected library](/assets/images/docs/tools/devtools/release-notes/images-2.8.0/image5.png "Outline view selected library")
 
 * Performance improvements to expression evaluation auto complete -
   [#3463](https://github.com/flutter/devtools/pull/3463)
+
+  改进了表达式求值自动完成的性能 -
+  [#3463](https://github.com/flutter/devtools/pull/3463)
 * Fixed a bug with keyboard shortcuts -
+  [#3458](https://github.com/flutter/devtools/pull/3458)
+
+  修复了键盘快捷键的 bug -
   [#3458](https://github.com/flutter/devtools/pull/3458)
 * UI polish - [#3421](https://github.com/flutter/devtools/pull/3421),
   [#3449](https://github.com/flutter/devtools/pull/3449)
 
+  UI 优化 - [#3421](https://github.com/flutter/devtools/pull/3421),
+  [#3449](https://github.com/flutter/devtools/pull/3449)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.7.0...v2.8.0).
+
+要查看自上一版本以来的完整更改列表，请查看
+[GitHub 上的差异](https://github.com/flutter/devtools/compare/v2.7.0...v2.8.0)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.9.1.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.9.1.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.9.1 release notes
-shortTitle: 2.9.1 release notes
+# title: DevTools 2.9.1 release notes
+title: DevTools 2.9.1 发布说明
+# shortTitle: 2.9.1 release notes
+shortTitle: 2.9.1 发布说明
 breadcrumb: 2.9.1
-description: Release notes for Dart and Flutter DevTools version 2.9.1.
+# description: Release notes for Dart and Flutter DevTools version 2.9.1.
+description: Dart 和 Flutter DevTools 2.9.1 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.9.1 release of the Dart and Flutter DevTools
@@ -11,10 +15,19 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.9.1 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## Debugger updates
+
+## 调试器更新
 
 * Improve support for inspecting large lists and maps in
   the Debugger variables pane - [#3497](https://github.com/flutter/devtools/pull/3497)
+
+  改进了在调试器变量面板中
+  检查大型列表和 map 的支持 - [#3497](https://github.com/flutter/devtools/pull/3497)
 
   ![Inspection before](/assets/images/docs/tools/devtools/release-notes/images-2.9.1/image1.png "Inspection before")
 
@@ -25,17 +38,35 @@ To learn more about DevTools, check out the
   in the debugger to the selected object -
   [#3480](https://github.com/flutter/devtools/pull/3480)
 
+  添加了在程序资源管理器大纲视图中选择对象的支持。
+  选择对象将自动滚动调试器中的源代码
+  到所选对象 -
+  [#3480](https://github.com/flutter/devtools/pull/3480)
+
 ## Performance updates
+
+## 性能更新
 
 * Fix bugs with performance page search and improve performance -
   [#3515](https://github.com/flutter/devtools/pull/3515)
+
+  修复了性能页面搜索的 bug 并改进了性能 -
+  [#3515](https://github.com/flutter/devtools/pull/3515)
 * Added an enhanced tooltip for flutter frames -
+  [#3493](https://github.com/flutter/devtools/pull/3493)
+
+  为 Flutter 帧添加了增强的工具提示 -
   [#3493](https://github.com/flutter/devtools/pull/3493)
 
   ![Flutter frame tooltips](/assets/images/docs/tools/devtools/release-notes/images-2.9.1/image3.png "Flutter frame tooltips")
 
 ## Full commit history
 
+## 完整提交历史
+
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.8.0...v2.9.1).
+
+要查看自上一版本以来的完整更改列表，请查看
+[GitHub 上的差异](https://github.com/flutter/devtools/compare/v2.8.0...v2.9.1)。

--- a/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.9.2.md
+++ b/sites/docs/src/content/tools/devtools/release-notes/release-notes-2.9.2.md
@@ -1,9 +1,13 @@
 ---
-title: DevTools 2.9.2 release notes
-shortTitle: 2.9.2 release notes
+# title: DevTools 2.9.2 release notes
+title: DevTools 2.9.2 发布说明
+# shortTitle: 2.9.2 release notes
+shortTitle: 2.9.2 发布说明
 breadcrumb: 2.9.2
-description: Release notes for Dart and Flutter DevTools version 2.9.2.
+# description: Release notes for Dart and Flutter DevTools version 2.9.2.
+description: Dart 和 Flutter DevTools 2.9.2 版本发布说明。
 showToc: false
+ai-translated: true
 ---
 
 The 2.9.2 release of the Dart and Flutter DevTools
@@ -11,11 +15,21 @@ includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](https://docs.flutter.dev/tools/devtools).
 
+Dart 和 Flutter DevTools 的 2.9.2 版本包含以下更改以及其他常规改进。
+要了解更多关于 DevTools 的信息，请查看
+[DevTools 概览](https://docs.flutter.dev/tools/devtools)。
+
 ## General updates
+
+## 常规更新
 
 * Take our 2022 DevTools survey! Provide your feedback and help us improve
   your development experience. This survey prompt will show up directly in
   DevTools sometime in mid-February.
+
+  参加我们的 2022 DevTools 调查！提供你的反馈，帮助我们改进
+  你的开发体验。此调查提示将在 2 月中旬
+  直接显示在 DevTools 中。
 
   ![survey prompt](/assets/images/docs/tools/devtools/release-notes/images-2.9.2/image1.png "survey_prompt")
 
@@ -26,7 +40,20 @@ To learn more about DevTools, check out the
   prevented the survey from being able to be opened, and unless you
   are on Flutter 2.10, this bug will still be present._
 
+  *注意*：如果你在启动调查时遇到问题，请确保
+  你已升级到最新的 Flutter stable 分支 2.10。
+  DevTools 中有一个 bug（已在
+  [#3574](https://github.com/flutter/devtools/pull/3574) 中修复），
+  该 bug 导致无法打开调查，除非你
+  使用的是 Flutter 2.10，否则此 bug 仍然存在。_
+
 * General bug fixes and improvements -
+  [#3528](https://github.com/flutter/devtools/pull/3528),
+  [#3531](https://github.com/flutter/devtools/pull/3531),
+  [#3532](https://github.com/flutter/devtools/pull/3532),
+  [#3539](https://github.com/flutter/devtools/pull/3539)
+
+  常规 bug 修复和改进 -
   [#3528](https://github.com/flutter/devtools/pull/3528),
   [#3531](https://github.com/flutter/devtools/pull/3531),
   [#3532](https://github.com/flutter/devtools/pull/3532),
@@ -34,19 +61,35 @@ To learn more about DevTools, check out the
 
 ## Performance updates
 
+## 性能更新
+
 * Added frame numbers to x-axis the Flutter frames chart -
+  [#3526](https://github.com/flutter/devtools/pull/3526)
+
+  在 Flutter 帧图表的 x 轴上添加了帧编号 -
   [#3526](https://github.com/flutter/devtools/pull/3526)
 
   ![frame numbers](/assets/images/docs/tools/devtools/release-notes/images-2.9.2/image2.png "frame_numbers")
 
 ## Debugger updates
 
+## 调试器更新
+
 * Fix a bug where the File Explorer in the Debugger did not show contents
   after a hot restart -
   [#3527](https://github.com/flutter/devtools/pull/3527)
 
+  修复了调试器中的 File Explorer 在热重启后
+  不显示内容的 bug -
+  [#3527](https://github.com/flutter/devtools/pull/3527)
+
 ## Full commit history
+
+## 完整提交历史
 
 To find a complete list of changes since the previous release,
 check out
 [the diff on GitHub](https://github.com/flutter/devtools/compare/v2.9.1...v2.9.2).
+
+要查看自上一版本以来的完整更改列表，请查看
+[GitHub 上的差异](https://github.com/flutter/devtools/compare/v2.9.1...v2.9.2)。


### PR DESCRIPTION
## Summary

- Translate **57 DevTools release notes** (v2.7.0 through v2.58.0) into bilingual format
- All documents follow the established bilingual append-layer convention
- YAML frontmatter uses commented English + Chinese value pattern with `ai-translated: true`

### Scope
- 57 DevTools release notes covering Inspector, Performance, Debugger, Network, Memory, Logging, and other DevTools features

### Not translated (by design)
- 3 integration test example files (code-only, no translatable prose)
- 5 tree dump files (code-only debug output)
- 3 job listing pages (not user-facing documentation)
- 1 breaking change template file (developer tooling)

### Quality
- Zero format issues detected (list formatting, tip blocks, pronouns, translation tone)
- All CI checks pass on first attempt

## Test plan

- [x] `dart run dash_site build` passes
- [x] `dart run dash_site --site=docs check-link-references` passes
- [x] `dart run dash_site --site=docs refresh-excerpts --fail-on-update --dry-run` passes

Made with [Cursor](https://cursor.com)